### PR TITLE
FEAT: Add port close command feature and improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.windsurfrules
+/.cursorrules

--- a/letmein-fwproto/src/lib.rs
+++ b/letmein-fwproto/src/lib.rs
@@ -41,6 +41,8 @@ pub enum FirewallOperation {
     Ack,
     /// Open a port.
     Open,
+    /// Close a port.
+    Close,
 }
 
 impl TryFrom<u16> for FirewallOperation {
@@ -48,10 +50,12 @@ impl TryFrom<u16> for FirewallOperation {
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
         const OPERATION_OPEN: u16 = FirewallOperation::Open as u16;
+        const OPERATION_CLOSE: u16 = FirewallOperation::Close as u16;
         const OPERATION_ACK: u16 = FirewallOperation::Ack as u16;
         const OPERATION_NACK: u16 = FirewallOperation::Nack as u16;
         match value {
             OPERATION_OPEN => Ok(Self::Open),
+            OPERATION_CLOSE => Ok(Self::Close),
             OPERATION_ACK => Ok(Self::Ack),
             OPERATION_NACK => Ok(Self::Nack),
             _ => Err(err!("Invalid FirewallMessage/Operation value")),
@@ -213,6 +217,18 @@ impl FirewallMessage {
         }
     }
 
+    /// Construct a new message that requests removing a firewall-port-open rule.
+    pub fn new_close(addr: IpAddr, port_type: PortType, port: u16) -> Self {
+        let (addr_type, addr) = addr_to_octets(addr);
+        Self {
+            operation: FirewallOperation::Close,
+            port_type,
+            port,
+            addr_type,
+            addr,
+        }
+    }
+
     /// Get the operation type from this message.
     pub fn operation(&self) -> FirewallOperation {
         self.operation
@@ -221,7 +237,7 @@ impl FirewallMessage {
     /// Get the port number from this message.
     pub fn port(&self) -> Option<(PortType, u16)> {
         match self.operation {
-            FirewallOperation::Open => Some((self.port_type, self.port)),
+            FirewallOperation::Open | FirewallOperation::Close => Some((self.port_type, self.port)),
             FirewallOperation::Ack | FirewallOperation::Nack => None,
         }
     }
@@ -229,7 +245,7 @@ impl FirewallMessage {
     /// Get the `IpAddr` from this message.
     pub fn addr(&self) -> Option<IpAddr> {
         match self.operation {
-            FirewallOperation::Open => Some(octets_to_addr(self.addr_type, &self.addr)),
+            FirewallOperation::Open | FirewallOperation::Close => Some(octets_to_addr(self.addr_type, &self.addr)),
             FirewallOperation::Ack | FirewallOperation::Nack => None,
         }
     }

--- a/letmein-proto/src/lib.rs
+++ b/letmein-proto/src/lib.rs
@@ -166,6 +166,12 @@ pub enum Operation {
     ///
     /// This message is not MiM-safe and not replay-safe by design.
     GoAway,
+
+    /// The `Close` message is sent by the client to request closing
+    /// a previously opened port.
+    ///
+    /// This message follows the same authentication sequence as Knock.
+    Close,
 }
 
 impl TryFrom<u32> for Operation {
@@ -177,12 +183,14 @@ impl TryFrom<u32> for Operation {
         const OPERATION_RESPONSE: u32 = Operation::Response as u32;
         const OPERATION_COMEIN: u32 = Operation::ComeIn as u32;
         const OPERATION_GOAWAY: u32 = Operation::GoAway as u32;
+        const OPERATION_CLOSE: u32 = Operation::Close as u32;
         match value {
             OPERATION_KNOCK => Ok(Self::Knock),
             OPERATION_CHALLENGE => Ok(Self::Challenge),
             OPERATION_RESPONSE => Ok(Self::Response),
             OPERATION_COMEIN => Ok(Self::ComeIn),
             OPERATION_GOAWAY => Ok(Self::GoAway),
+            OPERATION_CLOSE => Ok(Self::Close),
             _ => Err(err!("Invalid Message/Operation value")),
         }
     }
@@ -303,7 +311,7 @@ impl Message {
     #[must_use]
     pub fn check_auth_ok_no_challenge(&self, shared_key: &[u8]) -> bool {
         #[cfg(not(test))]
-        assert_eq!(self.operation(), Operation::Knock);
+        assert!(self.operation() == Operation::Knock || self.operation() == Operation::Close);
         self.auth
             .ct_eq(&self.authenticate_no_challenge(shared_key))
             .into()
@@ -322,7 +330,7 @@ impl Message {
     /// with the provided `shared_key`
     /// and store it in this message.
     pub fn generate_auth_no_challenge(&mut self, shared_key: &[u8]) {
-        assert_eq!(self.operation(), Operation::Knock);
+        assert!(self.operation() == Operation::Knock || self.operation() == Operation::Close);
         self.auth = self.authenticate_no_challenge(shared_key);
     }
 
@@ -676,7 +684,7 @@ mod tests {
     fn test_msg_raw_invalid_operation() {
         let bytes = [
             0x3B, 0x1B, 0xB7, 0x19, // magic
-            0x00, 0x00, 0x00, 0x05, // operation
+            0x00, 0x00, 0x00, 0x0A, // operation (using 10, which is invalid)
             0xF9, 0x02, 0x01, 0xB2, // user
             0xB3, 0xE4, 0x6B, 0x6C, // resource
             0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, // salt

--- a/letmein/src/command.rs
+++ b/letmein/src/command.rs
@@ -8,5 +8,6 @@
 
 pub mod genkey;
 pub mod knock;
+pub mod close;
 
 // vim: ts=4 sw=4 expandtab

--- a/letmein/src/command/close.rs
+++ b/letmein/src/command/close.rs
@@ -1,0 +1,225 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    client::Client,
+    resolver::{is_ipv4_addr, is_ipv6_addr, ResMode},
+};
+use anyhow::{self as ah, format_err as err, Context as _};
+use letmein_conf::{Config, ControlPort};
+use letmein_proto::{Key, Message, Operation, ResourceId, UserId};
+use std::{path::Path, sync::Arc, time::Duration};
+
+/// Close protocol sequence - client side.
+struct CloseSeq<'a> {
+    pub verbose: bool,
+    pub addr: &'a str,
+    pub control_port: ControlPort,
+    pub control_timeout: Duration,
+    pub user: UserId,
+    pub resource: ResourceId,
+    pub key: &'a Key,
+}
+
+impl CloseSeq<'_> {
+    /// Check if the server replied with a valid message.
+    fn check_reply(&self, msg: &Message) -> ah::Result<()> {
+        if msg.user() != self.user {
+            eprintln!(
+                "Warning: The server replied with a different user identifier. \
+                 Expected {}, but received {}.",
+                self.user,
+                msg.user(),
+            );
+            // continue processing this message.
+        }
+        if msg.resource() != self.resource {
+            eprintln!(
+                "Warning: The server replied with a different resource identifier. \
+                 Expected {}, but received {}.",
+                self.resource,
+                msg.resource(),
+            );
+            // continue processing this message.
+        }
+        Ok(())
+    }
+
+    /// Run the close protocol sequence.
+    pub async fn close_sequence(&self, resolver_mode: ResMode) -> ah::Result<()> {
+        if self.verbose {
+            println!(
+                "Connecting to letmein server '{}:{}'.",
+                self.addr, self.control_port
+            );
+        }
+        let mut client = Client::new(
+            self.addr,
+            self.control_port,
+            self.control_timeout,
+            resolver_mode,
+        )
+        .await
+        .context("Client init")?;
+
+        if self.verbose {
+            println!("Sending 'Close' packet.");
+        }
+        let mut close = Message::new(Operation::Close, self.user, self.resource);
+        close.generate_auth_no_challenge(self.key);
+        client.send_msg(close).await.context("Send close")?;
+
+        if self.verbose {
+            println!("Receiving 'Challenge' packet.");
+        }
+        let challenge = client.recv_specific_msg(Operation::Challenge).await?;
+        self.check_reply(&challenge)?;
+
+        if self.verbose {
+            println!("Sending 'Response' packet.");
+        }
+        let mut response = Message::new(Operation::Response, self.user, self.resource);
+        response.generate_auth(self.key, challenge);
+        client.send_msg(response).await.context("Send response")?;
+
+        if self.verbose {
+            println!("Receiving 'ComeIn' packet.");
+        }
+        let comein = client.recv_specific_msg(Operation::ComeIn).await?;
+        self.check_reply(&comein)?;
+
+        if self.verbose {
+            println!("Close sequence successful.");
+        }
+        Ok(())
+    }
+}
+
+pub struct CloseServer<'a> {
+    pub addr: &'a str,
+    pub addr_mode: super::knock::AddrMode,
+    pub port: Option<u16>,
+    pub port_tcp: bool,
+    pub port_udp: bool,
+}
+
+impl CloseServer<'_> {
+    pub fn to_control_port(&self, conf: &Config) -> ControlPort {
+        let mut control_port = conf.port();
+        if let Some(server_port) = self.port {
+            control_port.port = server_port;
+        }
+        if self.port_udp {
+            control_port.tcp = false;
+            control_port.udp = true;
+        }
+        if self.port_tcp {
+            control_port.tcp = true;
+            control_port.udp = false;
+        }
+        if control_port.tcp && control_port.udp {
+            control_port.udp = false; // prefer TCP
+        }
+        control_port
+    }
+}
+
+/// Run the `close` command.
+pub async fn run_close(
+    conf: Arc<Config>,
+    verbose: bool,
+    server: CloseServer<'_>,
+    close_port: u16,
+    user: Option<UserId>,
+) -> ah::Result<()> {
+    let confpath = conf.get_path().unwrap_or(Path::new(""));
+
+    let user = user.unwrap_or_else(|| conf.default_user());
+    let Some(key) = conf.key(user) else {
+        return Err(err!("No key found in {confpath:?} for user {user}"));
+    };
+    let Some(resource) = conf.resource_id_by_port(close_port, Some(user)) else {
+        return Err(err!(
+            "Port {close_port} is not mapped to a resource in {confpath:?}"
+        ));
+    };
+
+    let control_port = server.to_control_port(&conf);
+
+    let control_timeout = conf.control_timeout();
+
+    let seq = CloseSeq {
+        verbose,
+        addr: server.addr,
+        control_port,
+        control_timeout,
+        user,
+        resource,
+        key,
+    };
+
+    match server.addr_mode {
+        super::knock::AddrMode::TryBoth => {
+            if verbose {
+                println!(
+                    "Trying to close port {close_port} on '{}' IPv6 and IPv4.",
+                    server.addr
+                );
+            }
+            if is_ipv4_addr(server.addr) {
+                // For a raw IPv4 address only close IPv4.
+                seq.close_sequence(ResMode::Ipv4).await?;
+            } else if is_ipv6_addr(server.addr) {
+                // For a raw IPv6 address only close IPv6.
+                seq.close_sequence(ResMode::Ipv6).await?;
+            } else {
+                // For a hostname try IPv6 first, then IPv4.
+                match seq.close_sequence(ResMode::Ipv6).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        if verbose {
+                            eprintln!("IPv6 close failed: {e}");
+                            println!("Trying IPv4...");
+                        }
+                        seq.close_sequence(ResMode::Ipv4).await?;
+                    }
+                }
+            }
+        }
+        super::knock::AddrMode::Both => {
+            if verbose {
+                println!(
+                    "Closing port {close_port} on '{}' IPv6 and IPv4.",
+                    server.addr
+                );
+            }
+            seq.close_sequence(ResMode::Ipv6).await?;
+            seq.close_sequence(ResMode::Ipv4).await?;
+        }
+        super::knock::AddrMode::Ipv6 => {
+            if verbose {
+                println!(
+                    "Closing port {close_port} on '{}' IPv6.",
+                    server.addr
+                );
+            }
+            seq.close_sequence(ResMode::Ipv6).await?;
+        }
+        super::knock::AddrMode::Ipv4 => {
+            if verbose {
+                println!(
+                    "Closing port {close_port} on '{}' IPv4.",
+                    server.addr
+                );
+            }
+            seq.close_sequence(ResMode::Ipv4).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/letmein/src/main.rs
+++ b/letmein/src/main.rs
@@ -17,6 +17,7 @@ use crate::{
     command::{
         genkey::run_genkey,
         knock::{run_knock, KnockServer},
+        close::{run_close, CloseServer},
     },
     seccomp::install_seccomp_rules,
 };
@@ -70,6 +71,89 @@ fn parse_user(s: &str) -> ah::Result<UserId> {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Close a previously opened port on a server.
+    Close {
+        /// The host name, IPv4 or IPv6 address that you want to close the port on.
+        host: String,
+
+        /// The port on the remote host that you want to close.
+        port: u16,
+
+        /// The user identifier for authenticating the close request.
+        ///
+        /// The user identifier is a 8 digits hex number.
+        ///
+        /// The authentication key associated with this user identifier
+        /// will be fetched from the letmein.conf configuration file.
+        ///
+        /// If not given, then the `[CLIENT] default_user` from the
+        /// configuration file will be used instead.
+        /// If the configuration is not available, user 00000000 will
+        /// be used instead.
+        #[arg(short, long, value_parser = parse_user)]
+        user: Option<UserId>,
+
+        /// letmein server port number.
+        ///
+        /// You normally don't have to use this option.
+        ///
+        /// Set the letmein server port number to use when contacting the letmein server.
+        ///
+        /// If not given, then the `[GENERAL] port` from the
+        /// letmein.conf configuration file will be used instead.
+        /// If the configuration is not available, port 5800 will
+        /// be used instead.
+        #[arg(short = 'P', long)]
+        server_port: Option<u16>,
+
+        /// Enforce TCP connection to letmein server port.
+        ///
+        /// You normally don't have to use this option.
+        ///
+        /// If not given, then the `[GENERAL] port` from the
+        /// letmein.conf configuration file will be used instead.
+        /// TCP will be preferred, if both TCP and UDP are specified.
+        #[arg(short = 'T', long)]
+        server_port_tcp: bool,
+
+        /// Enforce UDP connection to letmein server port.
+        ///
+        /// You normally don't have to use this option.
+        ///
+        /// If not given, then the `[GENERAL] port` from the
+        /// letmein.conf configuration file will be used instead.
+        /// TCP will be preferred, if both TCP and UDP are specified.
+        #[arg(short = 'U', long)]
+        server_port_udp: bool,
+
+        /// Resolve HOST into an IPv4 address.
+        ///
+        /// Resolve the HOST into an IPv4 address and close the port on that address.
+        ///
+        /// If none of the --ipv4 and --ipv6 options are given,
+        /// then closing on both IPv4 and IPv6 is tried, but no error is
+        /// shown, if one of them failed.
+        ///
+        /// If both of the --ipv4 and --ipv6 options are given,
+        /// then closing on both IPv4 and IPv6 is done and an error is shown,
+        /// if any one fails.
+        #[arg(short = '4', long)]
+        ipv4: bool,
+
+        /// Resolve HOST into an IPv6 address.
+        ///
+        /// Resolve the HOST into an IPv6 address and close the port on that address.
+        ///
+        /// If none of the --ipv4 and --ipv6 options are given,
+        /// then closing on both IPv4 and IPv6 is tried, but no error is
+        /// shown, if one of them failed.
+        ///
+        /// If both of the --ipv4 and --ipv6 options are given,
+        /// then closing on both IPv4 and IPv6 is done and an error is shown,
+        /// if any one fails.
+        #[arg(short = '6', long)]
+        ipv6: bool,
+    },
     /// Knock a port open on a server.
     Knock {
         /// The host name, IPv4 or IPv6 address that you want to knock on.
@@ -199,6 +283,32 @@ async fn async_main(opts: Opts) -> ah::Result<()> {
                     port_udp: server_port_udp,
                 };
                 run_knock(
+                    conf,
+                    opts.verbose,
+                    server,
+                    port,
+                    user,
+                )
+                .await
+            }
+            Command::Close {
+                host,
+                port,
+                user,
+                server_port,
+                server_port_tcp,
+                server_port_udp,
+                ipv4,
+                ipv6,
+            } => {
+                let server = CloseServer {
+                    addr: &host,
+                    addr_mode: (ipv4, ipv6).into(),
+                    port: server_port,
+                    port_tcp: server_port_tcp,
+                    port_udp: server_port_udp,
+                };
+                run_close(
                     conf,
                     opts.verbose,
                     server,

--- a/letmeind/src/firewall_client.rs
+++ b/letmeind/src/firewall_client.rs
@@ -51,7 +51,35 @@ impl FirewallClient {
         match msg_reply.operation() {
             FirewallOperation::Ack => Ok(()),
             FirewallOperation::Nack => Err(err!("The firewall rejected the port-open request")),
-            FirewallOperation::Open => Err(err!("Received invalid reply")),
+            FirewallOperation::Open | FirewallOperation::Close => Err(err!("Received invalid reply")),
+        }
+    }
+
+    /// Send a request to close a firewall `port` for the specified `addr`.
+    pub async fn close_port(
+        &mut self,
+        addr: IpAddr,
+        port_type: PortType,
+        port: u16,
+    ) -> ah::Result<()> {
+        // Send a close-port request to the firewall daemon.
+        FirewallMessage::new_close(addr, port_type, port)
+            .send(&mut self.stream)
+            .await
+            .context("Send port-close message")?;
+
+        // Receive the close-port reply.
+        let Some(msg_reply) = FirewallMessage::recv(&mut self.stream)
+            .await
+            .context("Receive port-close reply")?
+        else {
+            return Err(err!("Connection terminated"));
+        };
+
+        match msg_reply.operation() {
+            FirewallOperation::Ack => Ok(()),
+            FirewallOperation::Nack => Err(err!("The firewall rejected the port-close request")),
+            FirewallOperation::Open | FirewallOperation::Close => Err(err!("Received invalid reply")),
         }
     }
 }

--- a/letmeinfwd/src/firewall.rs
+++ b/letmeinfwd/src/firewall.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for LeasePort {
 }
 
 /// TCP or UDP port number.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum SingleLeasePort {
     /// TCP port.
     Tcp(u16),
@@ -150,6 +150,15 @@ pub trait FirewallOpen {
     /// This operation shall handle the case where there already is such
     /// a rule present gracefully.
     async fn open_port(
+        &mut self,
+        conf: &Config,
+        remote_addr: IpAddr,
+        port: LeasePort,
+    ) -> ah::Result<()>;
+
+    /// Remove a rule that opens the specified `port` for the specified `remote_addr`.
+    /// This operation shall handle the case where there is no such rule present gracefully.
+    async fn close_port(
         &mut self,
         conf: &Config,
         remote_addr: IpAddr,


### PR DESCRIPTION
This commit implements the port close command feature that allows users to close previously opened ports. Changes include:

- Add close command implementation in client side
- Implement close_port method in firewall implementation
- Update protocol handling to support Close operation
- Add robust error handling for edge cases
- Implement detailed debug logging for better diagnostics
- Update test scripts to verify close command functionality with both IPv4 and IPv6
- Fix assertions to accept both Knock and Close operations

The implementation follows the same security patterns as the knock command with proper authentication.