### PR TITLE
Add revoke operation

### DIFF
--- a/doc/PROTOCOL.md
+++ b/doc/PROTOCOL.md
@@ -26,6 +26,7 @@ It has been randomly chosen.
 | 2            | RESPONSE       |
 | 3            | COMEIN         |
 | 4            | GOAWAY         |
+| 5            | REVOKE         |
 
 This field defines the message type.
 Only certain types of operations are allowed during different states of the communication.
@@ -164,6 +165,16 @@ The `OPERATION` field of this message shall be `GOAWAY`.
 The `USER` and `RESOURCE` fields of this message are always set to the same values used in the `KNOCK` message.
 
 The `SALT` and `AUTH` fields of this message are ignored.
+
+## Message: REVOKE
+
+The `OPERATION` field of this message shall be `REVOKE`.
+
+All other fields of the message shall be equal these of the `KNOCK` message type.
+
+The communication flow of a `REVOKE` communication is equal to that of a `KNOCK` communication.
+
+But the server reacts to `REVOKE` by closing/removing the resource instead of opening/adding it.
 
 ## Generate AUTH token
 

--- a/letmein-conf/src/lib.rs
+++ b/letmein-conf/src/lib.rs
@@ -169,6 +169,13 @@ impl Resource {
             users.contains(&id)
         }
     }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        match self {
+            Self::Port { timeout, .. } => *timeout,
+            Self::Jump { timeout, .. } => *timeout,
+        }
+    }
 }
 
 impl std::fmt::Display for Resource {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -52,7 +52,7 @@ run_tests_genkey()
     [ "$user" = "12345678" ] || die "Got invalid user"
 }
 
-run_tests_knock()
+run_tests_knock_revoke()
 {
     local test_type="$1"
 
@@ -79,6 +79,10 @@ run_tests_knock()
     wait_for_pidfile letmeinfwd "$pid_letmeinfwd"
     wait_for_pidfile letmeind "$pid_letmeind"
 
+    ########################
+    ### PORT resource
+
+    echo "\n"
     info "Knocking IPv6 + IPv4..."
     "$target/letmein" \
         --verbose \
@@ -88,6 +92,17 @@ run_tests_knock()
         localhost 42 \
         || die "letmein knock failed"
 
+    echo "\n"
+    info "Revoking IPv6 + IPv4..."
+    "$target/letmein" \
+        --verbose \
+        --config "$conf" \
+        revoke \
+        --user 12345678 \
+        localhost 42 \
+        || die "letmein revoke failed"
+
+    echo "\n"
     info "Knocking IPv4..."
     "$target/letmein" \
         --verbose \
@@ -98,6 +113,18 @@ run_tests_knock()
         localhost 42 \
         || die "letmein knock failed"
 
+    echo "\n"
+    info "Revoking IPv4..."
+    "$target/letmein" \
+        --verbose \
+        --config "$conf" \
+        revoke \
+        --user 12345678 \
+        --ipv4 \
+        localhost 42 \
+        || die "letmein revoke failed"
+
+    echo "\n"
     info "Knocking IPv6..."
     "$target/letmein" \
         --verbose \
@@ -108,6 +135,21 @@ run_tests_knock()
         localhost 42 \
         || die "letmein knock failed"
 
+    echo "\n"
+    info "Revoke IPv6..."
+    "$target/letmein" \
+        --verbose \
+        --config "$conf" \
+        revoke \
+        --user 12345678 \
+        --ipv6 \
+        localhost 42 \
+        || die "letmein revoke failed"
+
+    ########################
+    ### JUMP resource
+
+    echo "\n"
     info "Knocking jump resource IPv4..."
     "$target/letmein" \
         --verbose \
@@ -119,6 +161,19 @@ run_tests_knock()
         localhost \
         || die "letmein knock failed"
 
+    echo "\n"
+    info "Revoking jump resource IPv4..."
+    "$target/letmein" \
+        --verbose \
+        --config "$conf" \
+        revoke \
+        --user 12345678 \
+        --ipv4 \
+        --resource aabbccdd \
+        localhost \
+        || die "letmein revoke failed"
+
+    echo "\n"
     info "Knocking jump resource IPv6..."
     "$target/letmein" \
         --verbose \
@@ -129,6 +184,18 @@ run_tests_knock()
         --resource aabbccdd \
         localhost \
         || die "letmein knock failed"
+
+    echo "\n"
+    info "Revoking jump resource IPv6..."
+    "$target/letmein" \
+        --verbose \
+        --config "$conf" \
+        revoke \
+        --user 12345678 \
+        --ipv6 \
+        --resource aabbccdd \
+        localhost \
+        || die "letmein revoke failed"
 
     kill_all_and_wait
 }
@@ -214,8 +281,8 @@ info "Temporary directory is: $tmpdir"
 build_project
 cargo_clippy
 run_tests_genkey
-run_tests_knock tcp
-run_tests_knock udp
+run_tests_knock_revoke tcp
+run_tests_knock_revoke udp
 info "All tests Ok."
 
 # vim: ts=4 sw=4 expandtab


### PR DESCRIPTION
Add `revoke` operation to let the user explicitly close ports and remove jump rules.

This PR is a re-implementation of #21 and supersedes it.
The review findings and changes the letmein architecture have been incorporated.

**Thanks a lot @arcker for the idea and for the first implementation.**
**Your help is greatly appreciated.**

Closes: #21
Closes: #24
