### PR TITLE
Ratelimiting Proposal

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -139,6 +139,54 @@ The recommended value is: `basic-auth`
 
 This option defaults to `control-error-policy=always`, if it is absent from the configuration.
 
+### `auth-max-attempts`
+
+The `auth-max-attempts` option specifies the maximum number of failed authentication attempts allowed from a single IP address within the time window before rate limiting is applied.
+
+This helps prevent brute-force attacks by limiting how many times an attacker can attempt to authenticate.
+
+IPv6 addresses are masked to a /56 prefix to prevent evasion by rotating the interface identifier.
+
+Possible values: Any positive integer
+
+This option defaults to `auth-max-attempts=5`, if it is absent from the configuration.
+
+### `auth-time-window`
+
+The `auth-time-window` option specifies the time window (in seconds) for counting failed authentication attempts.
+
+Failed attempts older than this window are not counted toward the rate limit.
+
+After this time window expires without additional failures, the failure count is reset.
+
+Possible values: Any positive number of seconds
+
+This option defaults to `auth-time-window=60`, if it is absent from the configuration.
+
+### `auth-base-delay`
+
+The `auth-base-delay` option specifies the initial delay (in seconds) imposed after the first failed authentication attempt.
+
+The delay increases exponentially with each subsequent failure using the formula: `base_delay * 2^(attempts-1)`.
+
+This exponential backoff makes brute-force attacks increasingly time-consuming.
+
+Possible values: Any positive number of seconds
+
+This option defaults to `auth-base-delay=1`, if it is absent from the configuration.
+
+### `auth-max-delay`
+
+The `auth-max-delay` option specifies the maximum delay (in seconds) after repeated failed authentication attempts.
+
+This caps the exponential backoff to prevent excessively long delays that could be used for denial-of-service attacks.
+
+Even with many failures, the delay will never exceed this maximum value.
+
+Possible values: Any positive number of seconds
+
+This option defaults to `auth-max-delay=300` (5 minutes), if it is absent from the configuration.
+
 ### `seccomp`
 
 The `seccomp` option turns [Seccomp](https://en.wikipedia.org/wiki/Seccomp) security hardening on or off.

--- a/letmein-conf/src/lib.rs
+++ b/letmein-conf/src/lib.rs
@@ -48,6 +48,10 @@ const CLIENT_CONF_PATH: &str = "letmein.conf";
 
 const DEFAULT_CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_NFT_TIMEOUT: Duration = Duration::from_secs(600);
+const DEFAULT_AUTH_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_AUTH_TIME_WINDOW: Duration = Duration::from_secs(60);
+const DEFAULT_AUTH_BASE_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_AUTH_MAX_DELAY: Duration = Duration::from_secs(300);
 
 const MAX_CHAIN_LEN: usize = 64;
 
@@ -428,6 +432,38 @@ fn get_seccomp(ini: &Ini) -> ah::Result<Seccomp> {
         return seccomp.parse();
     }
     Ok(Default::default())
+}
+
+fn get_auth_max_attempts(ini: &Ini) -> ah::Result<u32> {
+    if let Some(value) = ini.get("GENERAL", "auth-max-attempts") {
+        let value = value.trim();
+        if !is_number(value) {
+            return Err(err!("[GENERAL] auth-max-attempts: Invalid number"));
+        }
+        return value.parse().context("[GENERAL] auth-max-attempts");
+    }
+    Ok(DEFAULT_AUTH_MAX_ATTEMPTS)
+}
+
+fn get_auth_time_window(ini: &Ini) -> ah::Result<Duration> {
+    if let Some(value) = ini.get("GENERAL", "auth-time-window") {
+        return parse_duration(value).context("[GENERAL] auth-time-window");
+    }
+    Ok(DEFAULT_AUTH_TIME_WINDOW)
+}
+
+fn get_auth_base_delay(ini: &Ini) -> ah::Result<Duration> {
+    if let Some(value) = ini.get("GENERAL", "auth-base-delay") {
+        return parse_duration(value).context("[GENERAL] auth-base-delay");
+    }
+    Ok(DEFAULT_AUTH_BASE_DELAY)
+}
+
+fn get_auth_max_delay(ini: &Ini) -> ah::Result<Duration> {
+    if let Some(value) = ini.get("GENERAL", "auth-max-delay") {
+        return parse_duration(value).context("[GENERAL] auth-max-delay");
+    }
+    Ok(DEFAULT_AUTH_MAX_DELAY)
 }
 
 fn get_keys(ini: &Ini) -> ah::Result<HashMap<UserId, Key>> {
@@ -828,6 +864,10 @@ pub struct Config {
     control_timeout: Duration,
     control_error_policy: ErrorPolicy,
     seccomp: Seccomp,
+    auth_max_attempts: u32,
+    auth_time_window: Duration,
+    auth_base_delay: Duration,
+    auth_max_delay: Duration,
     keys: HashMap<UserId, Key>,
     resources: HashMap<ResourceId, Resource>,
     default_user: UserId,
@@ -848,6 +888,10 @@ impl Config {
             checksum: Default::default(),
             variant,
             control_timeout: DEFAULT_CONTROL_TIMEOUT,
+            auth_max_attempts: DEFAULT_AUTH_MAX_ATTEMPTS,
+            auth_time_window: DEFAULT_AUTH_TIME_WINDOW,
+            auth_base_delay: DEFAULT_AUTH_BASE_DELAY,
+            auth_max_delay: DEFAULT_AUTH_MAX_DELAY,
             nft_timeout: DEFAULT_NFT_TIMEOUT,
             ..Default::default()
         }
@@ -978,6 +1022,10 @@ impl Config {
         let control_timeout = get_control_timeout(ini)?;
         let control_error_policy = get_control_error_policy(ini)?;
         let seccomp = get_seccomp(ini)?;
+        let auth_max_attempts = get_auth_max_attempts(ini)?;
+        let auth_time_window = get_auth_time_window(ini)?;
+        let auth_base_delay = get_auth_base_delay(ini)?;
+        let auth_max_delay = get_auth_max_delay(ini)?;
         let keys = get_keys(ini)?;
         let resources = get_resources(ini)?;
         if self.variant == ConfigVariant::Client {
@@ -999,6 +1047,10 @@ impl Config {
         self.control_timeout = control_timeout;
         self.control_error_policy = control_error_policy;
         self.seccomp = seccomp;
+        self.auth_max_attempts = auth_max_attempts;
+        self.auth_time_window = auth_time_window;
+        self.auth_base_delay = auth_base_delay;
+        self.auth_max_delay = auth_max_delay;
         self.keys = keys;
         self.resources = resources;
         self.default_user = default_user;
@@ -1046,6 +1098,30 @@ impl Config {
     #[must_use]
     pub fn seccomp(&self) -> Seccomp {
         self.seccomp
+    }
+
+    /// Get the `auth-max-attempts` option from `[GENERAL]` section.
+    #[must_use]
+    pub fn auth_max_attempts(&self) -> u32 {
+        self.auth_max_attempts
+    }
+
+    /// Get the `auth-time-window` option from `[GENERAL]` section.
+    #[must_use]
+    pub fn auth_time_window(&self) -> Duration {
+        self.auth_time_window
+    }
+
+    /// Get the `auth-base-delay` option from `[GENERAL]` section.
+    #[must_use]
+    pub fn auth_base_delay(&self) -> Duration {
+        self.auth_base_delay
+    }
+
+    /// Get the `auth-max-delay` option from `[GENERAL]` section.
+    #[must_use]
+    pub fn auth_max_delay(&self) -> Duration {
+        self.auth_max_delay
     }
 
     /// Get a list of all configured users.

--- a/letmeind/letmeind.conf
+++ b/letmeind/letmeind.conf
@@ -38,6 +38,36 @@ control-timeout = 5.0
 # The default value is: always
 control-error-policy = always
 
+# Authentication rate limiting configuration.
+# These settings prevent brute-force attacks by limiting authentication attempts.
+
+# Maximum number of failed authentication attempts allowed within the time window.
+#
+# Possible values: Any positive integer
+# The default value is: 5
+#auth-max-attempts = 5
+
+# Time window (in seconds) for counting failed authentication attempts.
+# Failed attempts older than this window are not counted.
+#
+# Possible values: Any positive number of seconds
+# The default value is: 60
+#auth-time-window = 60
+
+# Base delay (in seconds) after the first failed authentication attempt.
+# The delay increases exponentially with each subsequent failure.
+#
+# Possible values: Any positive number of seconds
+# The default value is: 1
+#auth-base-delay = 1
+
+# Maximum delay (in seconds) after repeated failed authentication attempts.
+# This caps the exponential backoff to prevent excessively long delays.
+#
+# Possible values: Any positive number of seconds
+# The default value is: 300 (5 minutes)
+#auth-max-delay = 300
+
 # Turn the Linux seccomp feature on.
 #
 # Possible values: off, log, kill

--- a/letmeind/src/auth_rate_limiter.rs
+++ b/letmeind/src/auth_rate_limiter.rs
@@ -1,0 +1,296 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 - 2026 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv6Addr},
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+/// Entry tracking authentication attempts for a single IP address.
+#[derive(Debug, Clone)]
+struct RateLimitEntry {
+    /// Number of failed authentication attempts.
+    failed_attempts: u32,
+    /// Timestamp of the last failed attempt.
+    last_attempt: Instant,
+    /// Timestamp when the IP can attempt again (for exponential backoff).
+    next_allowed: Instant,
+}
+
+/// Rate limiter for authentication attempts based on client IP addresses.
+/// This prevents brute-force attacks by implementing:
+/// - Maximum failed attempts within a time window
+/// - Exponential backoff after repeated failures
+/// - Automatic cleanup of old entries
+pub struct AuthRateLimiter {
+    map: Mutex<HashMap<IpAddr, RateLimitEntry>>,
+    max_attempts: u32,
+    time_window: Duration,
+    base_delay: Duration,
+    max_delay: Duration,
+}
+
+impl AuthRateLimiter {
+    /// Create a new `AuthRateLimiter` with the specified parameters.
+    ///
+    /// # Arguments
+    /// * `max_attempts` - Maximum failed attempts allowed within the time window
+    /// * `time_window` - Time window for counting failed attempts (e.g., 60 seconds)
+    /// * `base_delay` - Initial delay after first failure (e.g., 1 second)
+    /// * `max_delay` - Maximum delay after repeated failures (e.g., 300 seconds)
+    #[must_use]
+    pub fn new(
+        max_attempts: u32,
+        time_window: Duration,
+        base_delay: Duration,
+        max_delay: Duration,
+    ) -> Self {
+        Self {
+            map: Mutex::new(HashMap::new()),
+            max_attempts,
+            time_window,
+            base_delay,
+            max_delay,
+        }
+    }
+
+    /// Normalize an IP address to a rate-limiting key.
+    ///
+    /// IPv4 addresses are used as-is.
+    /// IPv6 addresses are masked to a /56 prefix to prevent evasion by rotating the interface identifier.
+    fn rate_limit_key(addr: IpAddr) -> IpAddr {
+        match addr {
+            IpAddr::V4(_) => addr,
+            IpAddr::V6(v6) => {
+                IpAddr::V6(v6 & Ipv6Addr::new(0xFFFF, 0xFFFF, 0xFFFF, 0xFF00, 0, 0, 0, 0))
+            }
+        }
+    }
+
+    /// Check if an authentication attempt is allowed for the given IP address.
+    ///
+    /// Returns `Ok(())` if the attempt is allowed, or `Err(Duration)` with the
+    /// remaining wait time if the attempt should be blocked.
+    pub fn check_attempt_allowed(&self, addr: IpAddr) -> Result<(), Duration> {
+        let key = Self::rate_limit_key(addr);
+        let now = Instant::now();
+        let mut map = self.map.lock().expect("Mutex poisoned");
+
+        // Clean up old entries (older than time_window)
+        map.retain(|_, entry| now.duration_since(entry.last_attempt) < self.time_window * 2);
+
+        if let Some(entry) = map.get(&key) {
+            // Check if we're still in the backoff period
+            if now < entry.next_allowed {
+                let wait_time = entry.next_allowed.duration_since(now);
+                return Err(wait_time);
+            }
+
+            // Check if we're within the time window and have exceeded max attempts
+            if now.duration_since(entry.last_attempt) < self.time_window
+                && entry.failed_attempts >= self.max_attempts
+            {
+                // Still within time window and max attempts exceeded
+                let wait_time = self
+                    .time_window
+                    .saturating_sub(now.duration_since(entry.last_attempt));
+                return Err(wait_time);
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a failed authentication attempt for the given IP address.
+    ///
+    /// This updates the failure count and calculates the next allowed attempt time
+    /// using exponential backoff.
+    pub fn record_failed_attempt(&self, addr: IpAddr) {
+        let key = Self::rate_limit_key(addr);
+        let now = Instant::now();
+        let mut map = self.map.lock().expect("Mutex poisoned");
+
+        let entry = map.entry(key).or_insert_with(|| RateLimitEntry {
+            failed_attempts: 0,
+            last_attempt: now,
+            next_allowed: now,
+        });
+
+        // Reset counter if outside the time window
+        if now.duration_since(entry.last_attempt) >= self.time_window {
+            entry.failed_attempts = 1;
+        } else {
+            entry.failed_attempts = entry.failed_attempts.saturating_add(1);
+        }
+        entry.last_attempt = now;
+
+        // Calculate exponential backoff: base_delay * 2^(attempts-1)
+        // Capped at max_delay
+        let delay = if entry.failed_attempts > 0 {
+            let exponent = (entry.failed_attempts - 1).min(10); // Cap exponent to prevent overflow
+            let multiplier = 1_u32 << exponent; // 2^exponent
+            let calculated_delay = self.base_delay.saturating_mul(multiplier);
+            calculated_delay.min(self.max_delay)
+        } else {
+            self.base_delay
+        };
+        entry.next_allowed = now + delay;
+    }
+
+    /// Record a successful authentication for the given IP address.
+    ///
+    /// This clears any rate limiting state for the IP.
+    pub fn record_success(&self, addr: IpAddr) {
+        let key = Self::rate_limit_key(addr);
+        let mut map = self.map.lock().expect("Mutex poisoned");
+        map.remove(&key);
+    }
+
+    /// Get the current number of failed attempts for an IP address.
+    ///
+    /// Returns 0 if the IP has no recorded failures or if the time window has expired.
+    #[must_use]
+    #[allow(dead_code)] // Used in tests
+    pub fn get_failed_attempts(&self, addr: IpAddr) -> u32 {
+        let key = Self::rate_limit_key(addr);
+        let now = Instant::now();
+        let map = self.map.lock().expect("Mutex poisoned");
+
+        if let Some(entry) = map.get(&key)
+            && now.duration_since(entry.last_attempt) < self.time_window
+        {
+            return entry.failed_attempts;
+        }
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{net::Ipv4Addr, thread, time::Duration};
+
+    #[test]
+    fn test_basic_rate_limiting() {
+        let limiter = AuthRateLimiter::new(
+            3,                          // max 3 attempts
+            Duration::from_secs(60),    // within 60 seconds
+            Duration::from_millis(100), // base delay 100ms
+            Duration::from_secs(10),    // max delay 10s
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+
+        // First attempt should be allowed
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // After first failure, need to wait for backoff
+        thread::sleep(Duration::from_millis(110));
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // After second failure, need to wait for backoff
+        thread::sleep(Duration::from_millis(210));
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // 4th attempt should be blocked (max attempts reached)
+        thread::sleep(Duration::from_millis(410));
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+    }
+
+    #[test]
+    fn test_exponential_backoff() {
+        let limiter = AuthRateLimiter::new(
+            10, // high max to test backoff
+            Duration::from_secs(60),
+            Duration::from_millis(50), // 50ms base delay
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2));
+
+        // First failure
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+        thread::sleep(Duration::from_millis(60)); // Wait for backoff
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+
+        // Second failure - should have longer backoff
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+    }
+
+    #[test]
+    fn test_success_clears_state() {
+        let limiter = AuthRateLimiter::new(
+            3,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 3));
+
+        // Record failures
+        limiter.record_failed_attempt(addr);
+        limiter.record_failed_attempt(addr);
+        assert_eq!(limiter.get_failed_attempts(addr), 2);
+
+        // Success should clear
+        limiter.record_success(addr);
+        assert_eq!(limiter.get_failed_attempts(addr), 0);
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+    }
+
+    #[test]
+    fn test_ipv6_prefix_masking() {
+        let limiter = AuthRateLimiter::new(
+            2,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        );
+
+        // Two IPv6 addresses in the same /56 subnet
+        let addr1 = "2001:db8:1234:5600::1".parse::<IpAddr>().unwrap();
+        let addr2 = "2001:db8:1234:5600::2".parse::<IpAddr>().unwrap();
+
+        // Failures from addr1 should affect addr2
+        limiter.record_failed_attempt(addr1);
+        limiter.record_failed_attempt(addr1);
+
+        // addr2 should also be rate limited
+        assert!(limiter.check_attempt_allowed(addr2).is_err());
+    }
+
+    #[test]
+    fn test_time_window_expiry() {
+        let limiter = AuthRateLimiter::new(
+            2,
+            Duration::from_millis(100), // Short window for testing
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 4));
+
+        // Max out attempts
+        limiter.record_failed_attempt(addr);
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+
+        // Wait for time window to expire
+        thread::sleep(Duration::from_millis(150));
+
+        // Should be allowed again
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+    }
+}

--- a/letmeind/src/main.rs
+++ b/letmeind/src/main.rs
@@ -11,6 +11,7 @@
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 std::compile_error!("letmeind server does not support non-Linux platforms.");
 
+mod auth_rate_limiter;
 mod firewall_client;
 mod ip_limiter;
 mod protocol;
@@ -18,6 +19,7 @@ mod seccomp;
 mod server;
 
 use crate::{
+    auth_rate_limiter::AuthRateLimiter,
     ip_limiter::IpLimiter,
     protocol::Protocol,
     seccomp::install_seccomp_rules,
@@ -168,6 +170,12 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
             let ip_limiter = Arc::new(IpLimiter::new(
                 opts.num_ip_connections.min(opts.num_connections),
             ));
+            let auth_rate_limiter = Arc::new(AuthRateLimiter::new(
+                conf.auth_max_attempts(),
+                conf.auth_time_window(),
+                conf.auth_base_delay(),
+                conf.auth_max_delay(),
+            ));
 
             loop {
                 match srv.accept().await {
@@ -196,9 +204,11 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
                             let conf = Arc::clone(&conf);
                             let opts = Arc::clone(&opts);
                             let ip_limiter = Arc::clone(&ip_limiter);
+                            let auth_rate_limiter = Arc::clone(&auth_rate_limiter);
 
                             async move {
-                                let mut proto = Protocol::new(&*conn, &conf, &opts.rundir);
+                                let mut proto =
+                                    Protocol::new(&*conn, &conf, &opts.rundir, &auth_rate_limiter);
                                 if let Err(e) = proto.run().await {
                                     eprintln!(
                                         "Client '{}/{}' ERROR: {}",

--- a/letmeind/src/protocol.rs
+++ b/letmeind/src/protocol.rs
@@ -6,11 +6,13 @@
 // or the MIT license, at your option.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{firewall_client::FirewallClient, server::ConnectionOps};
+use crate::{
+    auth_rate_limiter::AuthRateLimiter, firewall_client::FirewallClient, server::ConnectionOps,
+};
 use anyhow::{self as ah, format_err as err};
 use letmein_conf::{Config, ErrorPolicy, Resource};
 use letmein_proto::{Message, Operation, ResourceId, UserId};
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 use tokio::time::timeout;
 
 /// Protocol authentication state.
@@ -32,17 +34,24 @@ pub struct Protocol<'a, C> {
     conn: &'a C,
     conf: &'a Config,
     rundir: &'a Path,
+    auth_rate_limiter: &'a Arc<AuthRateLimiter>,
     user_id: Option<UserId>,
     resource_id: Option<ResourceId>,
     auth_state: AuthState,
 }
 
 impl<'a, C: ConnectionOps> Protocol<'a, C> {
-    pub fn new(conn: &'a C, conf: &'a Config, rundir: &'a Path) -> Self {
+    pub fn new(
+        conn: &'a C,
+        conf: &'a Config,
+        rundir: &'a Path,
+        auth_rate_limiter: &'a Arc<AuthRateLimiter>,
+    ) -> Self {
         Self {
             conn,
             conf,
             rundir,
+            auth_rate_limiter,
             user_id: None,
             resource_id: None,
             auth_state: AuthState::NotAuth,
@@ -136,6 +145,20 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
         self.resource_id = None;
         self.auth_state = AuthState::NotAuth;
 
+        // Check rate limiting before processing the request
+        let peer_ip = self.conn.peer_addr().ip();
+        if let Err(wait_time) = self.auth_rate_limiter.check_attempt_allowed(peer_ip) {
+            eprintln!(
+                "[{peer_ip}]: Rate limit exceeded. Must wait {:.1}s before next attempt.",
+                wait_time.as_secs_f64()
+            );
+            return self
+                .send_go_away(Err(err!(
+                    "Rate limit exceeded. Too many authentication attempts."
+                )))
+                .await;
+        }
+
         // Receive the initial knock/revoke message.
         let initial_message = self
             .recv_msg(&[Operation::Knock, Operation::Revoke])
@@ -159,6 +182,8 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
         // Authenticate the received message.
         // This check is not replay-safe. But that's fine.
         if !initial_message.check_auth_ok_no_challenge(key) {
+            // Record failed authentication attempt
+            self.auth_rate_limiter.record_failed_attempt(peer_ip);
             return self
                 .send_go_away(Err(err!("Knock: Authentication failed")))
                 .await;
@@ -217,11 +242,16 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
 
         // Authenticate the challenge-response.
         if !response.check_auth_ok(key, challenge) {
+            // Record failed authentication attempt
+            self.auth_rate_limiter.record_failed_attempt(peer_ip);
             return self
                 .send_go_away(Err(err!("Response: Authentication failed")))
                 .await;
         }
         self.auth_state = AuthState::ChallengeResponseAuth;
+
+        // Record successful authentication
+        self.auth_rate_limiter.record_success(peer_ip);
 
         // Reconfigure the firewall.
         let peer_ip_addr = self.conn.peer_addr().ip();

--- a/letmeind/tests/test_auth_rate_limiter.rs
+++ b/letmeind/tests/test_auth_rate_limiter.rs
@@ -1,0 +1,220 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 - 2026 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Integration test for auth_rate_limiter module
+// Since letmeind is a binary crate, we need to include the module directly
+
+#[path = "../src/auth_rate_limiter.rs"]
+mod auth_rate_limiter;
+
+#[cfg(test)]
+mod tests {
+    use super::auth_rate_limiter::AuthRateLimiter;
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        thread,
+        time::Duration,
+    };
+
+    #[test]
+    fn test_basic_rate_limiting() {
+        let limiter = AuthRateLimiter::new(
+            3,                          // max 3 attempts
+            Duration::from_secs(60),    // within 60 seconds
+            Duration::from_millis(100), // base delay 100ms
+            Duration::from_secs(10),    // max delay 10s
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+
+        // First attempt should be allowed
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // After first failure, need to wait for backoff
+        thread::sleep(Duration::from_millis(110));
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // After second failure, need to wait for backoff
+        thread::sleep(Duration::from_millis(210));
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+        limiter.record_failed_attempt(addr);
+
+        // 4th attempt should be blocked (max attempts reached)
+        thread::sleep(Duration::from_millis(410));
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+    }
+
+    #[test]
+    fn test_exponential_backoff() {
+        let limiter = AuthRateLimiter::new(
+            10, // high max to test backoff
+            Duration::from_secs(60),
+            Duration::from_millis(50), // 50ms base delay
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2));
+
+        // First failure
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+        thread::sleep(Duration::from_millis(60)); // Wait for backoff
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+
+        // Second failure - should have longer backoff
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+    }
+
+    #[test]
+    fn test_success_clears_state() {
+        let limiter = AuthRateLimiter::new(
+            3,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 3));
+
+        // Record failures
+        limiter.record_failed_attempt(addr);
+        limiter.record_failed_attempt(addr);
+        assert_eq!(limiter.get_failed_attempts(addr), 2);
+
+        // Success should clear
+        limiter.record_success(addr);
+        assert_eq!(limiter.get_failed_attempts(addr), 0);
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+    }
+
+    #[test]
+    fn test_ipv6_prefix_masking() {
+        let limiter = AuthRateLimiter::new(
+            2,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        );
+
+        // Two IPv6 addresses in the same /56 subnet
+        let addr1 = "2001:db8:1234:5600::1".parse::<IpAddr>().unwrap();
+        let addr2 = "2001:db8:1234:5600::2".parse::<IpAddr>().unwrap();
+
+        // Failures from addr1 should affect addr2
+        limiter.record_failed_attempt(addr1);
+        limiter.record_failed_attempt(addr1);
+
+        // addr2 should also be rate limited
+        assert!(limiter.check_attempt_allowed(addr2).is_err());
+    }
+
+    #[test]
+    fn test_time_window_expiry() {
+        let limiter = AuthRateLimiter::new(
+            2,
+            Duration::from_millis(100), // Short window for testing
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 4));
+
+        // Max out attempts
+        limiter.record_failed_attempt(addr);
+        limiter.record_failed_attempt(addr);
+        assert!(limiter.check_attempt_allowed(addr).is_err());
+
+        // Wait for time window to expire
+        thread::sleep(Duration::from_millis(150));
+
+        // Should be allowed again
+        assert!(limiter.check_attempt_allowed(addr).is_ok());
+    }
+
+    #[test]
+    fn test_different_ips_independent() {
+        let limiter = AuthRateLimiter::new(
+            2,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        );
+
+        let addr1 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5));
+        let addr2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        // Max out addr1
+        limiter.record_failed_attempt(addr1);
+        limiter.record_failed_attempt(addr1);
+        assert!(limiter.check_attempt_allowed(addr1).is_err());
+
+        // addr2 should still be allowed
+        assert!(limiter.check_attempt_allowed(addr2).is_ok());
+    }
+
+    #[test]
+    fn test_max_delay_cap() {
+        let limiter = AuthRateLimiter::new(
+            20, // high max to test many failures
+            Duration::from_secs(60),
+            Duration::from_secs(1), // 1 second base delay
+            Duration::from_secs(5), // 5 second max delay
+        );
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 6));
+
+        // Record many failures to trigger exponential backoff
+        for _ in 0..10 {
+            limiter.record_failed_attempt(addr);
+        }
+
+        // Check that delay is capped
+        if let Err(wait_time) = limiter.check_attempt_allowed(addr) {
+            // Should be capped at max_delay (5 seconds)
+            assert!(wait_time <= Duration::from_secs(5));
+        } else {
+            panic!("Expected rate limit error");
+        }
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        use std::sync::Arc;
+
+        let limiter = Arc::new(AuthRateLimiter::new(
+            5,
+            Duration::from_secs(60),
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        ));
+
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 7));
+
+        // Spawn multiple threads accessing the same limiter
+        let handles: Vec<_> = (0..3)
+            .map(|_| {
+                let limiter = Arc::clone(&limiter);
+                thread::spawn(move || {
+                    limiter.record_failed_attempt(addr);
+                    limiter.check_attempt_allowed(addr)
+                })
+            })
+            .collect();
+
+        // Wait for all threads to complete
+        for handle in handles {
+            let _ = handle.join();
+        }
+
+        // Verify state is consistent
+        assert_eq!(limiter.get_failed_attempts(addr), 3);
+    }
+}


### PR DESCRIPTION
Adds brute-force protection to letmeind via a new AuthRateLimiter module
- tracks failed authentication attempts per IP address (with IPv6 /56 prefix grouping to prevent subnet evasion) 
- exponential backoff once a configurable threshold is exceeded. 
- Rejects blocked clients early and record pass/fail outcomes on each authentication exchange. 
- Four new config options (auth-max-attempts, auth-time-window, auth-base-delay, auth-max-delay) with defaults 5 attempts / 60 s window / 1 s base delay / 5 min cap.