### PR TITLE
Improve structured security logging and fail2ban integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "letmein-fail2ban"
+version = "12.5.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "letmein-fwproto"
 version = "12.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 members = [
     "letmein",
     "letmein-conf",
+    "letmein-fail2ban",
     "letmein-fwproto",
     "letmein-proto",
     "letmein-seccomp",

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -86,6 +86,16 @@ Installing the server will also install the service and socket into systemd and 
 The server is used to receive knock packets from the client.
 Upon successful knock authentication, the server will open the knocked port in its `nftables` firewall.
 
+## Log management
+
+letmein and letmeind write all log output to stderr, which is captured by
+journald on systemd systems. No log files are created and no rotation
+configuration is needed for a standard install.
+
+For retention tuning, syslog forwarding, and platform-specific guidance see
+the [Log management](doc/SECURITY_LOGGING.md#log-management) section of
+`doc/SECURITY_LOGGING.md`.
+
 ## Installing with `cargo install` from crates.io
 
 Alternatively, you can install letmein, letmeind and letmeinfwd with `cargo install` from [crates.io](https://crates.io/).

--- a/doc/SECURITY_LOGGING.md
+++ b/doc/SECURITY_LOGGING.md
@@ -1,0 +1,174 @@
+# letmeind Security Logging
+
+letmeind emits structured security log lines for all authentication and connection
+events. These logs are designed to be parsed by **fail2ban**, **SIEM** systems,
+and other intrusion-detection tools.
+
+## Log format
+
+```
+letmeind: [<LEVEL>] <EVENT> peer=<IP> proto=<TCP|UDP> [key=value ...] -- <human message>
+```
+
+| Field | Description |
+|---|---|
+| `LEVEL` | `INFO`, `WARN`, or `ERROR` (see below) |
+| `EVENT` | Stable keyword identifying the event type (never changes between releases) |
+| `peer=` | IP address of the remote client |
+| `proto=` | Transport protocol: `TCP` or `UDP` |
+| `key=value` | Optional structured fields relevant to the event |
+| `--` | Separator between machine-readable fields and the human message |
+
+### Log levels
+
+| Token | Meaning |
+|---|---|
+| `INFO` | Normal, expected events |
+| `WARN` | Suspicious events that a legitimate client should not produce |
+| `ERROR` | Events that a legitimate, correctly configured client will never produce |
+
+Under systemd/journald, stdout and stderr are captured automatically. The process name
+and PID are prepended by the journal, so a forwarded syslog entry looks like:
+
+```
+letmeind[1234]: letmeind: [WARN] AUTH_FAILURE peer=192.0.2.50 proto=TCP user=DEADBEEF resource=0000539F stage=knock -- Initial knock authentication (HMAC) failed
+```
+
+## Event keyword reference
+
+These keywords are **stable** - they will not be renamed without a deprecation notice.
+Use them as anchors in fail2ban filter `failregex` and SIEM pattern rules.
+
+| Keyword | Level | Fail2ban target | Description |
+|---|---|---|---|
+| `CONN_LIMIT_EXCEEDED` | WARN | yes | Per-IP simultaneous connection limit exceeded. Possible scanner or DoS. |
+| `PREAUTH_TIMEOUT` | WARN | yes | Client connected but did not send any data within the timeout. Possible scanner or Slowloris attempt. |
+| `POSTAUTH_TIMEOUT` | WARN | no | Timeout during the challenge-response sequence after basic auth. |
+| `AUTH_FAILURE` | WARN | yes | HMAC authentication check failed. Wrong key, brute-force, or replay attempt. `stage=knock` is the first check; `stage=challenge-response` is the full check. |
+| `UNKNOWN_USER` | WARN | yes | User ID in the knock packet is not in the server configuration. |
+| `UNKNOWN_RESOURCE` | WARN | yes | Resource ID is not in the server configuration (after basic auth). |
+| `ACCESS_DENIED` | WARN | yes | Authenticated user is not permitted to access the requested resource. |
+| `PROTOCOL_ABUSE` | ERROR | yes (maxretry=1) | Wrong message operation in the handshake sequence, or user/resource ID changed mid-session. A legitimate client will never produce this. |
+| `KNOCK_SUCCESS` | INFO | no | Firewall rule installed. `user=` and `resource=` identify what was opened. |
+| `REVOKE_SUCCESS` | INFO | no | Firewall rule removed. |
+| `GOAWAY_SEND_FAILED`  | WARN | no | Server tried to send a rejection message to the client but the write failed. |
+| `SECCOMP_ACTIVE`        | INFO | no | Seccomp syscall filter installed at startup. `mode=log` or `mode=kill`. |
+| `SECCOMP_DISABLED`      | WARN (server/fwd), INFO (client) | no | Seccomp explicitly disabled in configuration. The server (`letmeind`) and firewall daemon (`letmeinfwd`) use `WARN` because disabling seccomp on a long-running daemon is a meaningful security reduction. The client (`letmein`) uses `INFO` because seccomp-off is a common and expected client configuration. |
+| `SECCOMP_UNAVAILABLE`   | WARN | no | Architecture does not support seccomp; filter not active. |
+| `SERVER_REPLY_MISMATCH` | WARN | no | **Client-side.** Server replied with a different user or resource ID than was sent. Possible rogue server or MitM. Emitted by the `letmein` client. |
+| `DNS_FALLBACK`          | WARN/INFO | no | **Client-side.** System DNS resolver failed; falling back to external resolvers. `WARN` when visible to the user; `INFO` on a quiet retry. `host=` and `addr_type=` fields identify the lookup. |
+| `CONFIG_INSECURE_OWNERSHIP`      | WARN | no | Config file is not owned by the expected UID. `path=`, `actual_uid=`, `expected_uid=` fields. Server only. |
+| `CONFIG_INSECURE_PERMISSIONS`    | WARN | no | Config file has overly permissive mode bits. `path=`, `mode=`, `recommended=` fields. Server only. |
+| `CONFIG_PERMISSION_CHECK_FAILED` | WARN | no | Could not stat the config file to check permissions. `path=` field. Server only. |
+| `UDP_MALFORMED_PACKET`    | WARN | no | UDP datagram received with wrong size. `peer=` (IP only), `expected_size=`, `actual_size=` fields. |
+| `UDP_QUEUE_OVERFLOW`      | WARN | no | Single peer flooded the UDP RX queue; connection dropped. `peer=` (IP only), `queue_max=` fields. |
+| `UDP_CONN_LIMIT_EXCEEDED`  | WARN | no | UDP connection table full; new connection dropped. `peer=` (IP only), `conn_max=` fields. |
+| `FIREWALL_RULE_SKIPPED`    | WARN | no | A firewall rule could not be installed - either the nftables rule comment exceeded the kernel length limit, or the client's IP version is incompatible with the configured nftables family. `reason=`, `peer=` fields. The knock fails safely (port stays closed). |
+
+The `letmeinfwd` firewall daemon emits these additional events directly to stderr:
+
+| Line fragment | Meaning |
+|---|---|
+| `letmeinfwd: [INFO] LEASE_EXPIRED --` | A timed-out firewall lease was removed. |
+| `letmeinfwd: [WARN] FIREWALL_REBUILD_TRIGGERED --` | A lease rule removal failed; letmeinfwd triggered a full nftables table rebuild. |
+| `letmeinfwd: [ERROR] FIREWALL_SHUTDOWN_FAILED --`   | Firewall rules could not be removed on daemon shutdown. Leased ports may remain open. |
+| `letmeinfwd: [WARN] IPC_CONF_MISMATCH --`           | letmeind and letmeinfwd loaded different config checksums. Firewall request rejected. |
+| `letmeinfwd: [ERROR] IPC_UNAUTHORIZED_CONNECT --`   | Something other than letmeind connected to the firewall IPC socket. `connected_pid/uid/gid=` and `expected_*=` fields. |
+| `letmeinfwd: [WARN] IPC_MALFORMED_MESSAGE --`       | letmeinfwd received a structurally invalid IPC message (missing checksum or missing client address). `reason=` field. A correctly functioning letmeind will never produce this. |
+
+
+## Example log lines
+
+```
+# Successful knock
+letmeind: [INFO] KNOCK_SUCCESS peer=192.168.1.10 proto=TCP user=A1B2C3D4 resource=0000539F -- Resource 0000539F successfully knocked. Firewall rules changed.
+
+# Wrong key / brute force
+letmeind: [WARN] AUTH_FAILURE peer=192.168.1.50 proto=TCP user=DEADBEEF resource=0000539F stage=knock -- Initial knock authentication (HMAC) failed
+
+# Challenge-response replay / MitM
+letmeind: [WARN] AUTH_FAILURE peer=192.168.1.50 proto=TCP user=DEADBEEF resource=0000539F stage=challenge-response -- Challenge-response authentication (HMAC) failed
+
+# Scanner / Slowloris
+letmeind: [WARN] PREAUTH_TIMEOUT peer=198.51.100.7 proto=TCP -- Connection timed out before client sent initial message
+
+# Malformed / junk packet (operation out of sequence)
+letmeind: [ERROR] PROTOCOL_ABUSE peer=198.51.100.7 proto=UDP expected=[Knock, Revoke] got=ComeIn -- Unexpected message operation - protocol sequence violated
+
+# Connection flood from one IP
+letmeind: [WARN] CONN_LIMIT_EXCEEDED peer=10.0.0.1 proto=TCP -- Per-IP simultaneous connection limit exceeded. Connection dropped.
+
+# Unknown user probe
+letmeind: [WARN] UNKNOWN_USER peer=203.0.113.99 proto=TCP user=CAFEBABE -- User ID not found in server configuration
+
+# Expired firewall lease (from letmeinfwd)
+letmeinfwd: [INFO] LEASE_EXPIRED -- Lease(client_addr=192.168.1.10, Port(443/TCP))
+```
+
+## Fail2ban integration
+
+See `scripts/fail2ban/` for ready-to-use filter and jail configuration files.
+
+### Quick start
+
+```bash
+# Copy files into place
+sudo cp scripts/fail2ban/filter.d/letmeind.conf /etc/fail2ban/filter.d/
+sudo cp scripts/fail2ban/jail.d/letmeind.conf   /etc/fail2ban/jail.d/
+
+# Reload fail2ban
+sudo systemctl reload fail2ban
+
+# Verify the filter matches your logs
+sudo fail2ban-regex /var/log/syslog /etc/fail2ban/filter.d/letmeind.conf
+# (or use journalctl output if syslog forwarding is not configured)
+```
+
+### Journald without syslog forwarding
+
+If your system uses journald but does not forward to `/var/log/syslog`, configure
+the jail to read from the journal:
+
+```ini
+[letmeind-auth]
+backend = systemd
+journalmatch = SYSLOG_IDENTIFIER=letmeind
+```
+
+### Recommended jail strategy
+
+| Jail | Event(s) | `maxretry` | `findtime` | `bantime` |
+|---|---|---|---|---|
+| `letmeind-auth` | `AUTH_FAILURE`, `UNKNOWN_USER`, `ACCESS_DENIED` | 5 | 60s | 600s |
+| `letmeind-abuse` | `PROTOCOL_ABUSE` | 1 | 60s | 86400s |
+| `letmeind-scan` | `PREAUTH_TIMEOUT`, `CONN_LIMIT_EXCEEDED` | 3 | 30s | 3600s |
+| `letmeind-probe` | `UNKNOWN_RESOURCE` | 10 | 120s | 300s |
+
+A single `PROTOCOL_ABUSE` event is a strong indicator of automated scanning or
+exploit tooling - ban immediately (`maxretry=1`) and for a long period.
+
+`AUTH_FAILURE` at `stage=challenge-response` means the attacker passed the initial
+HMAC check (they know a valid user ID and resource ID) but failed the replay-safe
+part. This is more serious than a basic `stage=knock` failure.
+
+## SIEM integration
+
+The structured `key=value` fields before `--` can be extracted with most log
+parsers. Example Grok pattern for Elastic/Logstash:
+
+```
+letmeind: \[%{WORD:level}\] %{WORD:event} peer=%{IP:src_ip} proto=%{WORD:proto}( %{DATA:kv_fields})? -- %{GREEDYDATA:message}
+```
+
+Suggested alert rules:
+
+- Alert on any `ERROR` level event from a new source IP.
+- Alert on `AUTH_FAILURE` count > 10 from the same IP within 5 minutes.
+- Alert on `PROTOCOL_ABUSE` - any occurrence warrants investigation.
+- Dashboard: `KNOCK_SUCCESS` / `REVOKE_SUCCESS` events show which users are accessing which resources and from where.
+
+## Log management
+
+letmein and letmeind write all output to **stderr**. On Linux with systemd this is captured by journald automatically — no log files or rotation configuration are needed. View live daemon logs with `journalctl -u letmeind.service -f`, or filter for security events with `journalctl -u letmeind.service | grep -E '\[(WARN|ERROR)\]'`. For explicit retention, set `MaxRetentionSec=90day` and `SystemMaxUse=500M` in `/etc/systemd/journald.conf` (90 days is the minimum recommended for security audit). If you forward to syslog, filter on `$programname == 'letmeind'` in rsyslog or `program("letmeind")` in syslog-ng and apply standard logrotate with `rotate 90`.
+
+On systems without systemd (OpenRC, runit, s6) redirect stderr to `/var/log/letmeind.log` in your service definition and apply the logrotate config above. The `letmein` client is short-lived and emits at most one or two lines per invocation; log volume is negligible on all platforms. On macOS, pipe through `logger -t letmein` to send to the Unified Logging system. On Windows, redirect stderr to a file with `2>letmein.log` and rotate weekly if needed.

--- a/letmein-conf/src/lib.rs
+++ b/letmein-conf/src/lib.rs
@@ -942,28 +942,49 @@ impl Config {
                     if let Some(good_uid) = good_uid {
                         let actual_uid = meta.uid();
                         if actual_uid != good_uid {
-                            eprintln!(
-                                "WARNING: \
-                                Configuration file '{dpath}' has insecure ownership: UID={actual_uid}.\n\
-                                Recommended: chown root:letmeind {dpath}"
-                            );
+                            match self.variant {
+                                ConfigVariant::Server => eprintln!(
+                                    "letmeind: [WARN] CONFIG_INSECURE_OWNERSHIP \
+                                    path={dpath} actual_uid={actual_uid} expected_uid={good_uid} \
+                                    -- WARNING: Configuration file has insecure ownership. \
+                                    Recommended: chown root:letmeind {dpath}"
+                                ),
+                                ConfigVariant::Client => eprintln!(
+                                    "WARNING: Configuration file '{dpath}' has insecure \
+                                    ownership: UID={actual_uid}.\n\
+                                    Recommended: chown root {dpath}"
+                                ),
+                            }
                         }
                     }
                     let mode = meta.mode() & 0o777;
                     if (mode & mask) != 0 {
-                        eprintln!(
-                            "WARNING: \
-                            Configuration file '{dpath}' has insecure permissions: {mode:o}.\n\
-                            Recommended: chmod {recommended:o} {dpath}"
-                        );
+                        match self.variant {
+                            ConfigVariant::Server => eprintln!(
+                                "letmeind: [WARN] CONFIG_INSECURE_PERMISSIONS \
+                                path={dpath} mode={mode:o} recommended={recommended:o} \
+                                -- WARNING: Configuration file has insecure permissions. \
+                                Recommended: chmod {recommended:o} {dpath}"
+                            ),
+                            ConfigVariant::Client => eprintln!(
+                                "WARNING: Configuration file '{dpath}' has insecure \
+                                permissions: {mode:o}.\n\
+                                Recommended: chmod {recommended:o} {dpath}"
+                            ),
+                        }
                     }
                 }
-                Err(e) => {
-                    eprintln!(
-                        "WARNING: \
-                        Failed to check configuration file permissions for '{dpath}': {e}"
-                    );
-                }
+                Err(e) => match self.variant {
+                    ConfigVariant::Server => eprintln!(
+                        "letmeind: [WARN] CONFIG_PERMISSION_CHECK_FAILED \
+                            path={dpath} \
+                            -- WARNING: Failed to check configuration file permissions: {e}"
+                    ),
+                    ConfigVariant::Client => eprintln!(
+                        "WARNING: Failed to check configuration file permissions \
+                            for '{dpath}': {e}"
+                    ),
+                },
             }
         }
 

--- a/letmein-fail2ban/Cargo.toml
+++ b/letmein-fail2ban/Cargo.toml
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+[package]
+name = "letmein-fail2ban"
+description = "Authenticated port knocking - fail2ban filter and jail configuration"
+version = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+categories = { workspace = true }
+keywords = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+
+[lints]
+workspace = true
+
+# vim: ts=4 sw=4 expandtab

--- a/letmein-fail2ban/configs/filter.d/letmeind-abuse.conf
+++ b/letmein-fail2ban/configs/filter.d/letmeind-abuse.conf
@@ -1,0 +1,18 @@
+# Fail2ban filter - PROTOCOL_ABUSE only.
+# Used by the letmeind-abuse jail (ban on first occurrence).
+# See filter.d/letmeind.conf for the full combined filter.
+#
+# PROTOCOL_ABUSE fires at [ERROR] for wrong-operation-in-sequence and at [WARN]
+# for malformed messages (bad magic, unknown op byte, size mismatch).  Both are
+# covered here - a legitimate client never produces either line.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+# Wrong operation in the protocol sequence (e.g. sending Knock twice).
+failregex = ^%(__prefix_line)sletmeind: \[ERROR\] PROTOCOL_ABUSE peer=<HOST> .*$
+
+# Malformed message - wrong size, invalid magic, or unknown operation byte.
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] PROTOCOL_ABUSE peer=<HOST> .*$
+ignoreregex =

--- a/letmein-fail2ban/configs/filter.d/letmeind-auth.conf
+++ b/letmein-fail2ban/configs/filter.d/letmeind-auth.conf
@@ -1,0 +1,12 @@
+# Fail2ban filter - AUTH_FAILURE, UNKNOWN_USER, ACCESS_DENIED only.
+# Used by the letmeind-auth jail.
+# See filter.d/letmeind.conf for the full combined filter.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^%(__prefix_line)sletmeind: \[WARN\] AUTH_FAILURE peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UNKNOWN_USER peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] ACCESS_DENIED peer=<HOST> .*$
+ignoreregex =

--- a/letmein-fail2ban/configs/filter.d/letmeind-probe.conf
+++ b/letmein-fail2ban/configs/filter.d/letmeind-probe.conf
@@ -1,0 +1,10 @@
+# Fail2ban filter - UNKNOWN_RESOURCE only.
+# Used by the letmeind-probe jail.
+# See filter.d/letmeind.conf for the full combined filter.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^%(__prefix_line)sletmeind: \[WARN\] UNKNOWN_RESOURCE peer=<HOST> .*$
+ignoreregex =

--- a/letmein-fail2ban/configs/filter.d/letmeind-scan.conf
+++ b/letmein-fail2ban/configs/filter.d/letmeind-scan.conf
@@ -1,0 +1,21 @@
+# Fail2ban filter - scanner / connection-flood events.
+# Used by the letmeind-scan jail.
+# See filter.d/letmeind.conf for the full combined filter.
+#
+# Events covered:
+#   PREAUTH_TIMEOUT     - client connected but sent nothing (port scan / Slowloris).
+#   POSTAUTH_TIMEOUT    - client authenticated but stalled mid-sequence.
+#   CONN_LIMIT_EXCEEDED - same IP opened too many simultaneous TCP connections.
+#   UDP_MALFORMED_PACKET  - UDP datagram with wrong size (probe / fuzzer).
+#   UDP_QUEUE_OVERFLOW    - single peer flooded the UDP RX queue.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+failregex = ^%(__prefix_line)sletmeind: \[WARN\] PREAUTH_TIMEOUT peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] POSTAUTH_TIMEOUT peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] CONN_LIMIT_EXCEEDED peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UDP_MALFORMED_PACKET peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UDP_QUEUE_OVERFLOW peer=<HOST> .*$
+ignoreregex =

--- a/letmein-fail2ban/configs/filter.d/letmeind.conf
+++ b/letmein-fail2ban/configs/filter.d/letmeind.conf
@@ -1,0 +1,86 @@
+# Fail2ban filter for letmeind - the letmein port-knocking daemon.
+#
+# This filter matches ALL security-relevant events.
+# Use separate jails (see jail.d/letmeind.conf) with different failregex
+# subsets to apply different maxretry / bantime per event class.
+#
+# Install: copy to /etc/fail2ban/filter.d/letmeind.conf
+# Test:    fail2ban-regex /var/log/syslog /etc/fail2ban/filter.d/letmeind.conf
+#          (or pipe `journalctl -u letmeind` if syslog forwarding is off)
+#
+# See doc/SECURITY_LOGGING.md for the full log format specification.
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+
+# ---------------------------------------------------------------------------
+# AUTH_FAILURE - wrong HMAC key; brute-force / wrong-key attempt.
+# Triggered at both the initial knock stage and the challenge-response stage.
+# Recommended: maxretry=5, findtime=60, bantime=600
+# ---------------------------------------------------------------------------
+failregex = ^%(__prefix_line)sletmeind: \[WARN\] AUTH_FAILURE peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# PROTOCOL_ABUSE - wrong operation in sequence ([ERROR]), or malformed message
+# (bad magic, unknown op byte, size mismatch - [WARN]).
+# A legitimate client will NEVER produce either line.
+# Recommended: maxretry=1, findtime=60, bantime=86400
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[ERROR\] PROTOCOL_ABUSE peer=<HOST> .*$
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] PROTOCOL_ABUSE peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# PREAUTH_TIMEOUT - client connected but sent nothing within the timeout.
+# Classic scanner or Slowloris behaviour.
+# Recommended: maxretry=3, findtime=30, bantime=3600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] PREAUTH_TIMEOUT peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# POSTAUTH_TIMEOUT - client authenticated but stalled mid-sequence.
+# Recommended: maxretry=3, findtime=30, bantime=3600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] POSTAUTH_TIMEOUT peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# CONN_LIMIT_EXCEEDED - same IP opened too many simultaneous TCP connections.
+# Recommended: maxretry=1, findtime=30, bantime=3600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] CONN_LIMIT_EXCEEDED peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# UDP_MALFORMED_PACKET - UDP datagram received with wrong size (probe/fuzzer).
+# Recommended: maxretry=3, findtime=30, bantime=3600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UDP_MALFORMED_PACKET peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# UDP_QUEUE_OVERFLOW - single peer flooded the UDP RX queue.
+# Recommended: maxretry=1, findtime=30, bantime=3600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UDP_QUEUE_OVERFLOW peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# UNKNOWN_USER - knock packet contains a user ID not in config.
+# Could be a probe or a misconfigured client.
+# Recommended: maxretry=5, findtime=60, bantime=600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UNKNOWN_USER peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# ACCESS_DENIED - authenticated user attempted a resource they are not
+# permitted to access.
+# Recommended: maxretry=3, findtime=60, bantime=600
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] ACCESS_DENIED peer=<HOST> .*$
+
+# ---------------------------------------------------------------------------
+# UNKNOWN_RESOURCE - valid user but unknown resource ID.
+# Less critical; likely misconfiguration on the client side.
+# Recommended: maxretry=10, findtime=120, bantime=300
+# ---------------------------------------------------------------------------
+failregex += ^%(__prefix_line)sletmeind: \[WARN\] UNKNOWN_RESOURCE peer=<HOST> .*$
+
+ignoreregex =

--- a/letmein-fail2ban/configs/jail.d/letmeind.conf
+++ b/letmein-fail2ban/configs/jail.d/letmeind.conf
@@ -1,0 +1,112 @@
+# Fail2ban jail definitions for letmeind - the letmein port-knocking daemon.
+#
+# Install: copy to /etc/fail2ban/jail.d/letmeind.conf
+# Reload:  systemctl reload fail2ban
+#
+# You must also install the filter files from scripts/fail2ban/filter.d/
+# into /etc/fail2ban/filter.d/.
+#
+# Adjust banaction, bantime, findtime, and maxretry to your threat model.
+# See doc/SECURITY_LOGGING.md for detailed guidance.
+#
+# Set logpath to wherever your syslog writes letmeind messages, or switch to
+# backend=systemd (see the commented block at the bottom of this file).
+
+# ---------------------------------------------------------------------------
+# letmeind-auth
+# Filter: letmeind-auth  (AUTH_FAILURE, UNKNOWN_USER, ACCESS_DENIED)
+# Targets brute-force / wrong-key attacks and privilege probing.
+# ---------------------------------------------------------------------------
+[letmeind-auth]
+enabled  = true
+filter   = letmeind-auth
+logpath  = /var/log/syslog
+           /var/log/messages
+maxretry = 5
+findtime = 60
+bantime  = 600
+# banaction = nftables-multiport  # recommended when letmein itself uses nftables
+
+# ---------------------------------------------------------------------------
+# letmeind-abuse
+# Filter: letmeind-abuse  (PROTOCOL_ABUSE)
+# A legitimate client never sends a bad operation sequence.
+# Ban on the very first occurrence for 24 hours.
+# ---------------------------------------------------------------------------
+[letmeind-abuse]
+enabled  = true
+filter   = letmeind-abuse
+logpath  = /var/log/syslog
+           /var/log/messages
+maxretry = 1
+findtime = 60
+bantime  = 86400
+
+# ---------------------------------------------------------------------------
+# letmeind-scan
+# Filter: letmeind-scan  (PREAUTH_TIMEOUT, CONN_LIMIT_EXCEEDED)
+# Targets port scanners, Slowloris, and connection-flood attempts.
+# ---------------------------------------------------------------------------
+[letmeind-scan]
+enabled  = true
+filter   = letmeind-scan
+logpath  = /var/log/syslog
+           /var/log/messages
+maxretry = 3
+findtime = 30
+bantime  = 3600
+
+# ---------------------------------------------------------------------------
+# letmeind-probe
+# Filter: letmeind-probe  (UNKNOWN_RESOURCE)
+# Less aggressive - likely a misconfigured client rather than an attacker.
+# ---------------------------------------------------------------------------
+[letmeind-probe]
+enabled  = true
+filter   = letmeind-probe
+logpath  = /var/log/syslog
+           /var/log/messages
+maxretry = 10
+findtime = 120
+bantime  = 300
+
+# ---------------------------------------------------------------------------
+# Alternative: use the systemd journal as the log source (no syslog
+# forwarding required).  Uncomment these sections and remove the blocks
+# above to use journald directly.
+# ---------------------------------------------------------------------------
+# [letmeind-auth]
+# enabled      = true
+# filter       = letmeind-auth
+# backend      = systemd
+# journalmatch = SYSLOG_IDENTIFIER=letmeind
+# maxretry     = 5
+# findtime     = 60
+# bantime      = 600
+#
+# [letmeind-abuse]
+# enabled      = true
+# filter       = letmeind-abuse
+# backend      = systemd
+# journalmatch = SYSLOG_IDENTIFIER=letmeind
+# maxretry     = 1
+# findtime     = 60
+# bantime      = 86400
+#
+# [letmeind-scan]
+# enabled      = true
+# filter       = letmeind-scan
+# backend      = systemd
+# journalmatch = SYSLOG_IDENTIFIER=letmeind
+# maxretry     = 3
+# findtime     = 30
+# bantime      = 3600
+#
+# [letmeind-probe]
+# enabled      = true
+# filter       = letmeind-probe
+# backend      = systemd
+# journalmatch = SYSLOG_IDENTIFIER=letmeind
+# maxretry     = 10
+# findtime     = 120
+# bantime      = 300

--- a/letmein-fail2ban/src/install.rs
+++ b/letmein-fail2ban/src/install.rs
@@ -1,0 +1,114 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 - 2026 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Installation helper: write the embedded configs to the fail2ban directory.
+
+use crate::CONFIG_FILES;
+use anyhow::{self as ah, Context as _};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Options controlling how [`install`] behaves.
+#[derive(Debug, Clone, Default)]
+pub struct InstallOpts {
+    /// Overwrite files that already exist.
+    ///
+    /// Defaults to `false` - existing files are skipped with a note printed to
+    /// stderr so that local customisations are never silently destroyed.
+    pub overwrite: bool,
+}
+
+/// Install all fail2ban configuration files under `fail2ban_dir`.
+///
+/// `fail2ban_dir` is normally `/etc/fail2ban`.  The function creates the
+/// `filter.d/` and `jail.d/` sub-directories if they do not already exist.
+///
+/// Files are written with mode `0o644`.  Sub-directories are created with
+/// mode `0o755`.
+///
+/// # Errors
+///
+/// Returns an error if a directory cannot be created or a file cannot be
+/// written.
+pub fn install(fail2ban_dir: &Path, opts: &InstallOpts) -> ah::Result<()> {
+    for file in CONFIG_FILES {
+        let dir: PathBuf = fail2ban_dir.join(file.subdir);
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("Create fail2ban sub-directory {}", dir.display()))?;
+
+        let dest: PathBuf = dir.join(file.filename);
+
+        if dest.exists() && !opts.overwrite {
+            eprintln!(
+                "letmein-fail2ban: skipping {} (already exists; use --overwrite to replace)",
+                dest.display()
+            );
+            continue;
+        }
+
+        fs::write(&dest, file.content)
+            .with_context(|| format!("Write fail2ban config {}", dest.display()))?;
+
+        eprintln!("letmein-fail2ban: installed {}", dest.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_install_to_tempdir() {
+        let tmp =
+            std::env::temp_dir().join(format!("letmein-fail2ban-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp); // clean slate
+
+        install(&tmp, &InstallOpts::default()).expect("install failed");
+
+        // Every declared file must have been written.
+        for file in CONFIG_FILES {
+            let dest = tmp.join(file.subdir).join(file.filename);
+            assert!(dest.exists(), "missing: {}", dest.display());
+            let written = fs::read_to_string(&dest).unwrap();
+            assert_eq!(written, file.content);
+        }
+
+        let _ = fs::remove_dir_all(&tmp); // tidy up
+    }
+
+    #[test]
+    fn test_install_skip_existing() {
+        let tmp =
+            std::env::temp_dir().join(format!("letmein-fail2ban-test-skip-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+
+        // First install - writes everything.
+        install(&tmp, &InstallOpts::default()).expect("first install failed");
+
+        // Overwrite the first filter with custom content.
+        let first = &CONFIG_FILES[0];
+        let dest = tmp.join(first.subdir).join(first.filename);
+        fs::write(&dest, "CUSTOM").unwrap();
+
+        // Second install without overwrite - must leave the custom content.
+        install(&tmp, &InstallOpts::default()).expect("second install failed");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "CUSTOM");
+
+        // Third install with overwrite - must restore original.
+        install(&tmp, &InstallOpts { overwrite: true }).expect("overwrite install failed");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), first.content);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}
+
+// vim: ts=4 sw=4 expandtab

--- a/letmein-fail2ban/src/lib.rs
+++ b/letmein-fail2ban/src/lib.rs
@@ -1,0 +1,287 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 - 2026 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! # letmein-fail2ban
+//!
+//! This crate provides **ready-to-use fail2ban filter and jail configuration**
+//! for the `letmeind` port-knocking daemon.
+//!
+//! The configuration files are embedded at compile time from the
+//! `configs/` directory of this crate and exposed as typed constants.
+//! An [`install`] function can write them to the correct locations on a
+//! running system.
+//!
+//! ## Filter files
+//!
+//! | Constant | File | Jail |
+//! |---|---|---|
+//! | [`FILTER_ALL`] | `letmeind.conf` | Matches every security event (use for single-jail setups) |
+//! | [`FILTER_AUTH`] | `letmeind-auth.conf` | `AUTH_FAILURE`, `UNKNOWN_USER`, `ACCESS_DENIED` |
+//! | [`FILTER_ABUSE`] | `letmeind-abuse.conf` | `PROTOCOL_ABUSE` |
+//! | [`FILTER_SCAN`] | `letmeind-scan.conf` | `PREAUTH_TIMEOUT`, `CONN_LIMIT_EXCEEDED` |
+//! | [`FILTER_PROBE`] | `letmeind-probe.conf` | `UNKNOWN_RESOURCE` |
+//!
+//! ## Jail file
+//!
+//! | Constant | File |
+//! |---|---|
+//! | [`JAIL`] | `letmeind.conf` - four jails: auth, abuse, scan, probe |
+//!
+//! ## Quick install
+//!
+//! ```no_run
+//! letmein_fail2ban::install(
+//!     std::path::Path::new("/etc/fail2ban"),
+//!     &letmein_fail2ban::InstallOpts::default(),
+//! ).expect("failed to install fail2ban configuration");
+//! ```
+
+#![forbid(unsafe_code)]
+
+mod install;
+
+pub use crate::install::{InstallOpts, install};
+
+// ---------------------------------------------------------------------------
+// Embedded filter configuration files.
+// ---------------------------------------------------------------------------
+
+/// Combined filter matching all letmeind security events.
+///
+/// Suitable for single-jail setups.  For finer-grained control with different
+/// `maxretry`/`bantime` per event class use the per-category filters below.
+pub const FILTER_ALL: &str = include_str!("../configs/filter.d/letmeind.conf");
+
+/// Filter for authentication failures, unknown users, and access-denied events.
+///
+/// Intended for the `letmeind-auth` jail.
+pub const FILTER_AUTH: &str = include_str!("../configs/filter.d/letmeind-auth.conf");
+
+/// Filter for protocol-abuse events.
+///
+/// Intended for the `letmeind-abuse` jail.
+/// A single occurrence is enough to justify an immediate, long-duration ban.
+pub const FILTER_ABUSE: &str = include_str!("../configs/filter.d/letmeind-abuse.conf");
+
+/// Filter for scanner and connection-flood events.
+///
+/// Intended for the `letmeind-scan` jail.
+pub const FILTER_SCAN: &str = include_str!("../configs/filter.d/letmeind-scan.conf");
+
+/// Filter for unknown-resource probe events.
+///
+/// Intended for the `letmeind-probe` jail.
+pub const FILTER_PROBE: &str = include_str!("../configs/filter.d/letmeind-probe.conf");
+
+// ---------------------------------------------------------------------------
+// Embedded jail configuration file.
+// ---------------------------------------------------------------------------
+
+/// Jail configuration with four jails: auth, abuse, scan, and probe.
+///
+/// Each jail references the corresponding per-category filter above.
+pub const JAIL: &str = include_str!("../configs/jail.d/letmeind.conf");
+
+// ---------------------------------------------------------------------------
+// Typed descriptor of a single configuration file to install.
+// ---------------------------------------------------------------------------
+
+/// A single fail2ban configuration file to be installed.
+#[derive(Debug, Clone, Copy)]
+pub struct ConfigFile {
+    /// Sub-directory under the fail2ban base directory (e.g. `"filter.d"`).
+    pub subdir: &'static str,
+    /// File name (e.g. `"letmeind-auth.conf"`).
+    pub filename: &'static str,
+    /// File content.
+    pub content: &'static str,
+}
+
+/// All configuration files provided by this crate, in installation order.
+pub const CONFIG_FILES: &[ConfigFile] = &[
+    ConfigFile {
+        subdir: "filter.d",
+        filename: "letmeind.conf",
+        content: FILTER_ALL,
+    },
+    ConfigFile {
+        subdir: "filter.d",
+        filename: "letmeind-auth.conf",
+        content: FILTER_AUTH,
+    },
+    ConfigFile {
+        subdir: "filter.d",
+        filename: "letmeind-abuse.conf",
+        content: FILTER_ABUSE,
+    },
+    ConfigFile {
+        subdir: "filter.d",
+        filename: "letmeind-scan.conf",
+        content: FILTER_SCAN,
+    },
+    ConfigFile {
+        subdir: "filter.d",
+        filename: "letmeind-probe.conf",
+        content: FILTER_PROBE,
+    },
+    ConfigFile {
+        subdir: "jail.d",
+        filename: "letmeind.conf",
+        content: JAIL,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_files_non_empty() {
+        assert!(!FILTER_ALL.is_empty());
+        assert!(!FILTER_AUTH.is_empty());
+        assert!(!FILTER_ABUSE.is_empty());
+        assert!(!FILTER_SCAN.is_empty());
+        assert!(!FILTER_PROBE.is_empty());
+        assert!(!JAIL.is_empty());
+    }
+
+    #[test]
+    fn test_config_files_complete() {
+        assert_eq!(CONFIG_FILES.len(), 6);
+        for f in CONFIG_FILES {
+            assert!(!f.subdir.is_empty());
+            assert!(!f.filename.is_empty());
+            assert!(!f.content.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_filter_all_contains_all_events() {
+        // Every banneable event keyword from the logging spec must appear in the combined filter.
+        let events = [
+            "AUTH_FAILURE",
+            "PROTOCOL_ABUSE",
+            "PREAUTH_TIMEOUT",
+            "POSTAUTH_TIMEOUT",
+            "CONN_LIMIT_EXCEEDED",
+            "UDP_MALFORMED_PACKET",
+            "UDP_QUEUE_OVERFLOW",
+            "UNKNOWN_USER",
+            "ACCESS_DENIED",
+            "UNKNOWN_RESOURCE",
+        ];
+        for event in events {
+            assert!(
+                FILTER_ALL.contains(event),
+                "FILTER_ALL is missing event keyword: {event}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_jail_references_all_filters() {
+        // Each per-category filter name must be referenced in the jail file.
+        let filters = [
+            "letmeind-auth",
+            "letmeind-abuse",
+            "letmeind-scan",
+            "letmeind-probe",
+        ];
+        for filter in filters {
+            assert!(
+                JAIL.contains(filter),
+                "JAIL config does not reference filter: {filter}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_auth_events() {
+        // letmeind-auth must cover exactly its documented events and no others from
+        // the other jails (to avoid double-banning at wrong thresholds).
+        assert!(FILTER_AUTH.contains("AUTH_FAILURE"));
+        assert!(FILTER_AUTH.contains("UNKNOWN_USER"));
+        assert!(FILTER_AUTH.contains("ACCESS_DENIED"));
+        // Must NOT contain events belonging to other jails.
+        assert!(!FILTER_AUTH.contains("PROTOCOL_ABUSE"));
+        assert!(!FILTER_AUTH.contains("PREAUTH_TIMEOUT"));
+        assert!(!FILTER_AUTH.contains("UNKNOWN_RESOURCE"));
+    }
+
+    #[test]
+    fn test_filter_abuse_events() {
+        // letmeind-abuse covers both PROTOCOL_ABUSE severity levels.
+        assert!(FILTER_ABUSE.contains("PROTOCOL_ABUSE"));
+        // Both [ERROR] and [WARN] variants must be present.
+        assert!(FILTER_ABUSE.contains("[ERROR]"));
+        assert!(FILTER_ABUSE.contains("[WARN]"));
+        // Must NOT bleed into auth events.
+        assert!(!FILTER_ABUSE.contains("AUTH_FAILURE"));
+    }
+
+    #[test]
+    fn test_filter_scan_events() {
+        assert!(FILTER_SCAN.contains("PREAUTH_TIMEOUT"));
+        assert!(FILTER_SCAN.contains("POSTAUTH_TIMEOUT"));
+        assert!(FILTER_SCAN.contains("CONN_LIMIT_EXCEEDED"));
+        assert!(FILTER_SCAN.contains("UDP_MALFORMED_PACKET"));
+        assert!(FILTER_SCAN.contains("UDP_QUEUE_OVERFLOW"));
+        // Must NOT contain auth events.
+        assert!(!FILTER_SCAN.contains("AUTH_FAILURE"));
+        assert!(!FILTER_SCAN.contains("PROTOCOL_ABUSE"));
+    }
+
+    #[test]
+    fn test_filter_probe_events() {
+        assert!(FILTER_PROBE.contains("UNKNOWN_RESOURCE"));
+        // Probe is the least aggressive jail - must not contain high-severity events.
+        assert!(!FILTER_PROBE.contains("AUTH_FAILURE"));
+        assert!(!FILTER_PROBE.contains("PROTOCOL_ABUSE"));
+        assert!(!FILTER_PROBE.contains("PREAUTH_TIMEOUT"));
+    }
+
+    #[test]
+    fn test_filter_regex_format() {
+        // Every failregex line must contain <HOST> (fail2ban's IP placeholder)
+        // and end with .*$ so partial-line matches don't silently drop events.
+        for (name, content) in [
+            ("FILTER_ALL", FILTER_ALL),
+            ("FILTER_AUTH", FILTER_AUTH),
+            ("FILTER_ABUSE", FILTER_ABUSE),
+            ("FILTER_SCAN", FILTER_SCAN),
+            ("FILTER_PROBE", FILTER_PROBE),
+        ] {
+            for line in content.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("failregex") {
+                    assert!(
+                        trimmed.contains("<HOST>"),
+                        "{name}: failregex line missing <HOST>: {trimmed}"
+                    );
+                    assert!(
+                        trimmed.ends_with(".*$"),
+                        "{name}: failregex line does not end with .*$: {trimmed}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_jail_has_required_fields() {
+        // Every jail block must specify enabled, filter, maxretry, findtime, bantime.
+        for field in ["enabled", "filter", "maxretry", "findtime", "bantime"] {
+            assert!(
+                JAIL.contains(field),
+                "JAIL config is missing required field: {field}"
+            );
+        }
+    }
+}
+
+// vim: ts=4 sw=4 expandtab

--- a/letmein-fwproto/src/lib.rs
+++ b/letmein-fwproto/src/lib.rs
@@ -643,6 +643,65 @@ mod tests {
             ]
         );
     }
+    #[test]
+    fn test_msg_deserialize_size_mismatch() {
+        // Too short - one byte missing.
+        let short: Vec<u8> = vec![0_u8; FWMSG_SIZE - 1];
+        let err = FirewallMessage::try_msg_deserialize(&short).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+
+        // Too long - one extra byte.
+        let long: Vec<u8> = vec![0_u8; FWMSG_SIZE + 1];
+        let err = FirewallMessage::try_msg_deserialize(&long).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+
+        // Empty buffer.
+        let err = FirewallMessage::try_msg_deserialize(&[]).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_msg_deserialize_invalid_operation() {
+        // Build a valid Ack message then corrupt the operation field (0xFF, 0xFF).
+        let mut bytes = FirewallMessage::new_ack().msg_serialize().unwrap();
+        bytes[0] = 0xFF;
+        bytes[1] = 0xFF;
+        let err = FirewallMessage::try_msg_deserialize(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("Operation value"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_msg_deserialize_invalid_addr_type() {
+        // Build a valid Install message then corrupt the addr_type field (0xFF, 0xFF).
+        let mut bytes = FirewallMessage::new_install(
+            0x1234_5678.into(),
+            0xABCD_EF01.into(),
+            "1.2.3.4".parse().unwrap(),
+            &ConfigChecksum::calculate(b"test"),
+        )
+        .msg_serialize()
+        .unwrap();
+        // addr_type is at FWMSG_OFFS_ADDR_TYPE (bytes 10..12).
+        bytes[FWMSG_OFFS_ADDR_TYPE] = 0xFF;
+        bytes[FWMSG_OFFS_ADDR_TYPE + 1] = 0xFF;
+        let err = FirewallMessage::try_msg_deserialize(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("AddrType value"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 // vim: ts=4 sw=4 expandtab

--- a/letmein-proto/src/lib.rs
+++ b/letmein-proto/src/lib.rs
@@ -715,6 +715,32 @@ mod tests {
     }
 
     #[test]
+    fn test_msg_deserialize_size_mismatch() {
+        // Too short - one byte missing.
+        let short: Vec<u8> = vec![0_u8; MSG_SIZE - 1];
+        let err = Message::try_msg_deserialize(&short).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+
+        // Too long - one extra byte.
+        let long: Vec<u8> = vec![0_u8; MSG_SIZE + 1];
+        let err = Message::try_msg_deserialize(&long).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+
+        // Empty buffer.
+        let err = Message::try_msg_deserialize(&[]).unwrap_err();
+        assert!(
+            err.to_string().contains("size mismatch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "Invalid Message/Operation value")]
     fn test_msg_raw_invalid_operation() {
         let bytes = [

--- a/letmein-proto/src/socket.rs
+++ b/letmein-proto/src/socket.rs
@@ -88,11 +88,14 @@ impl<const MSG_SIZE: usize, const Q_SIZE: usize> UdpDispatcherRx<MSG_SIZE, Q_SIZ
         match socket.try_recv_from(&mut buf) {
             Ok((n, peer_addr)) => {
                 if n != MSG_SIZE {
-                    if DEBUG {
-                        eprintln!(
-                            "UDP-dispatcher: try_recv: Datagram invalid size {n} from {peer_addr}."
-                        );
-                    }
+                    // Malformed datagram - a valid letmein client always sends exactly
+                    // MSG_SIZE bytes.  Log unconditionally for security audit.
+                    eprintln!(
+                        "letmeind: [WARN] UDP_MALFORMED_PACKET \
+                        peer={} expected_size={MSG_SIZE} actual_size={n} \
+                        -- Dropping datagram: invalid size from peer",
+                        peer_addr.ip()
+                    );
                     return Ok(());
                 }
 
@@ -114,11 +117,13 @@ impl<const MSG_SIZE: usize, const Q_SIZE: usize> UdpDispatcherRx<MSG_SIZE, Q_SIZ
                 assert!(conn.rx_queue.len() <= Q_SIZE);
                 if conn.rx_queue.len() == Q_SIZE {
                     self.disconnect(peer_addr); // Close connection.
-                    if DEBUG {
-                        eprintln!(
-                            "UDP-dispatcher: try_recv {peer_addr}: RX-Q overflow (max={Q_SIZE})."
-                        );
-                    }
+                    // RX queue flood from a single peer - log for security audit.
+                    eprintln!(
+                        "letmeind: [WARN] UDP_QUEUE_OVERFLOW \
+                        peer={} queue_max={Q_SIZE} \
+                        -- Dropping connection: RX queue overflow from peer",
+                        peer_addr.ip()
+                    );
                     return Ok(());
                 }
                 conn.rx_queue.push_back(buf);
@@ -130,12 +135,14 @@ impl<const MSG_SIZE: usize, const Q_SIZE: usize> UdpDispatcherRx<MSG_SIZE, Q_SIZ
                 // we exceeded the maximum number of connections.
                 if self.conn.len() > self.max_nr_conn {
                     self.disconnect(peer_addr); // Close connection.
-                    if DEBUG {
-                        eprintln!(
-                            "UDP-dispatcher: try_recv {peer_addr}: Too many conns (max={}).",
-                            self.max_nr_conn
-                        );
-                    }
+                    // Connection table full - log for security audit.
+                    eprintln!(
+                        "letmeind: [WARN] UDP_CONN_LIMIT_EXCEEDED \
+                        peer={} conn_max={} \
+                        -- Dropping connection: too many simultaneous UDP connections",
+                        peer_addr.ip(),
+                        self.max_nr_conn
+                    );
                     return Ok(());
                 }
 

--- a/letmein/src/command/knock.rs
+++ b/letmein/src/command/knock.rs
@@ -64,22 +64,29 @@ impl KnockSeq<'_> {
     #[allow(clippy::unnecessary_wraps)]
     fn check_reply(&self, msg: &Message) -> ah::Result<()> {
         if msg.user() != self.user {
+            // Emit in the structured format used by letmeind so SIEM/audit logs
+            // from client and server can be correlated.  Also clearly visible to
+            // an interactive user via the SECURITY WARNING prefix.
             eprintln!(
-                "Warning: The server replied with a different user identifier. \
-                 Expected {}, but received {}.",
+                "letmein: [WARN] SERVER_REPLY_MISMATCH \
+                 expected_user={} received_user={} \
+                 -- SECURITY WARNING: Server replied with a different user identifier. \
+                 This may indicate a misconfigured or rogue server. \
+                 Knock attempt will continue but the result should not be trusted.",
                 self.user,
                 msg.user(),
             );
-            // continue processing this message.
         }
         if msg.resource() != self.resource {
             eprintln!(
-                "Warning: The server replied with a different resource identifier. \
-                 Expected {}, but received {}.",
+                "letmein: [WARN] SERVER_REPLY_MISMATCH \
+                 expected_resource={} received_resource={} \
+                 -- SECURITY WARNING: Server replied with a different resource identifier. \
+                 This may indicate a misconfigured or rogue server. \
+                 Knock attempt will continue but the result should not be trusted.",
                 self.resource,
                 msg.resource(),
             );
-            // continue processing this message.
         }
         Ok(())
     }

--- a/letmein/src/resolver/hickory.rs
+++ b/letmein/src/resolver/hickory.rs
@@ -60,18 +60,27 @@ pub async fn resolve(host: &str, cfg: &ResConf) -> ah::Result<IpAddr> {
         #[cfg(target_os = "android")]
         let print_warning = false;
 
-        if print_warning && !cfg.suppress_warnings {
+        if print_warning {
             #[cfg(target_os = "windows")]
             let os_info = "Is your DNS resolver configured correctly in network settings?";
 
             #[cfg(not(target_os = "windows"))]
             let os_info = "Is /etc/resolv.conf present and configured correctly?";
 
-            eprintln!(
-                "Warning: Could not resolve {addr_type_str} address with the system DNS resolver. \
-                 {os_info} \
-                 Falling back to other DNS servers."
-            );
+            if cfg.suppress_warnings {
+                // Quiet retry path (e.g. TryBoth mode) - log for audit only, no user output.
+                eprintln!(
+                    "letmein: [INFO] DNS_FALLBACK host={host} addr_type={addr_type_str} -- \
+                     System DNS resolver failed; falling back to external DNS servers."
+                );
+            } else {
+                // Normal path - structured audit line with human-readable warning for the user.
+                eprintln!(
+                    "letmein: [WARN] DNS_FALLBACK host={host} addr_type={addr_type_str} -- \
+                     Warning: Could not resolve {addr_type_str} address with the system DNS \
+                     resolver. {os_info} Falling back to other DNS servers."
+                );
+            }
         }
     }
 

--- a/letmein/src/seccomp.rs
+++ b/letmein/src/seccomp.rs
@@ -50,6 +50,11 @@ fn do_install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
     use anyhow::Context as _;
 
     if seccomp == Seccomp::Off {
+        // Normal for many client setups - log for audit but do not surface to the user.
+        eprintln!(
+            "letmein: [INFO] SECCOMP_DISABLED -- \
+            Seccomp syscall filter is disabled by configuration"
+        );
         return Ok(());
     }
 
@@ -65,10 +70,18 @@ fn do_install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
             .context("Compile seccomp filter")?
             .install()
             .context("Install seccomp filter")?;
-    } else {
+        // Log for audit; no need to surface to an interactive CLI user on every invocation.
         eprintln!(
-            "WARNING: Not using seccomp. \
-            Letmein does not support seccomp on this architecture, yet."
+            "letmein: [INFO] SECCOMP_ACTIVE mode={seccomp} -- \
+            Seccomp syscall filter installed successfully"
+        );
+    } else {
+        // Seccomp was requested but the architecture does not support it.
+        // Log for audit AND tell the user - their expected hardening is not in effect.
+        eprintln!(
+            "letmein: [WARN] SECCOMP_UNAVAILABLE -- \
+            WARNING: Seccomp was requested but is not supported on this architecture. \
+            Syscall filter not active."
         );
     }
 

--- a/letmeind/src/logging.rs
+++ b/letmeind/src/logging.rs
@@ -1,0 +1,99 @@
+// -*- coding: utf-8 -*-
+//
+// Copyright (C) 2024 - 2026 Michael Büsch <m@bues.ch>
+//
+// Licensed under the Apache License version 2.0
+// or the MIT license, at your option.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Structured security logging for letmeind.
+//!
+//! All security-relevant events are emitted as a single log line in a
+//! consistent, machine-readable format that fail2ban filters and SIEMs
+//! can parse reliably.
+//!
+//! # Line format
+//!
+//! ```text
+//! letmeind: [<LEVEL>] <EVENT> peer=<IP> proto=<TCP|UDP> [key=value ...] -- <human message>
+//! ```
+//!
+//! Journald captures stdout/stderr and adds the process name and PID automatically,
+//! so the prefix `letmeind[<PID>]:` appears in syslog-forwarded output.
+//!
+//! # Levels
+//!
+//! | Token   | Use                                              |
+//! |---------|--------------------------------------------------|
+//! | `INFO`  | Normal operation events (successful knock, etc.) |
+//! | `WARN`  | Suspicious but possibly legitimate events        |
+//! | `ERROR` | Events that should never occur with a valid client |
+//!
+//! # Event keywords (stable - do not rename without updating fail2ban configs)
+//!
+//! | Keyword               | Meaning                                           |
+//! |-----------------------|---------------------------------------------------|
+//! | `CONN_ACCEPT`         | New connection accepted                           |
+//! | `CONN_LIMIT_EXCEEDED` | Per-IP simultaneous connection limit exceeded     |
+//! | `PREAUTH_TIMEOUT`     | Timeout before client sent initial message        |
+//! | `POSTAUTH_TIMEOUT`    | Timeout after authentication during sequence      |
+//! | `PROTOCOL_ABUSE`      | Wrong operation in sequence or ID mismatch        |
+//! | `UNKNOWN_USER`        | User ID not found in server configuration         |
+//! | `UNKNOWN_RESOURCE`    | Resource ID not found in server configuration     |
+//! | `ACCESS_DENIED`       | Authenticated user not permitted for resource     |
+//! | `AUTH_FAILURE`        | Cryptographic authentication (HMAC) check failed  |
+//! | `KNOCK_SUCCESS`       | Firewall rule installed successfully              |
+//! | `REVOKE_SUCCESS`      | Firewall rule revoked successfully                |
+//! | `GOAWAY_SEND_FAILED`          | Could not send the GoAway rejection to client             |
+//! | `FIREWALL_REBUILD_TRIGGERED`  | Lease removal failed; full nftables table rebuild invoked |
+//! | `SECCOMP_ACTIVE`              | Seccomp syscall filter installed; `mode=log\|kill`        |
+//! | `SECCOMP_DISABLED`            | Seccomp explicitly disabled. `[WARN]` on server/fwd, `[INFO]` on client |
+//! | `SECCOMP_UNAVAILABLE`         | Architecture does not support seccomp                     |
+//! | `IPC_MALFORMED_MESSAGE`       | letmeinfwd received a structurally invalid IPC message (missing checksum/address). `reason=` field |
+
+/// Emit a structured security log line to stderr.
+///
+/// Two forms:
+///
+/// With extra key=value fields:
+/// ```rust,ignore
+/// log_security!(WARN, "AUTH_FAILURE", peer_ip, proto, "user=DEADBEEF stage=knock"
+///     => "Initial knock authentication failed");
+/// ```
+///
+/// Without extra fields:
+/// ```rust,ignore
+/// log_security!(WARN, "PREAUTH_TIMEOUT", peer_ip, proto
+///     => "Connection timed out before client sent initial message");
+/// ```
+///
+/// The `=>` separator splits machine-readable key=value pairs from the
+/// human-readable description.  Both parts end up on the same line.
+#[macro_export]
+macro_rules! log_security {
+    // With extra key=value fields:
+    ($level:ident, $event:expr, $peer:expr, $proto:expr, $fields:expr => $msg:expr) => {
+        eprintln!(
+            "letmeind: [{}] {} peer={} proto={} {} -- {}",
+            stringify!($level),
+            $event,
+            $peer,
+            $proto,
+            $fields,
+            $msg,
+        )
+    };
+    // Without extra fields:
+    ($level:ident, $event:expr, $peer:expr, $proto:expr => $msg:expr) => {
+        eprintln!(
+            "letmeind: [{}] {} peer={} proto={} -- {}",
+            stringify!($level),
+            $event,
+            $peer,
+            $proto,
+            $msg,
+        )
+    };
+}
+
+// vim: ts=4 sw=4 expandtab

--- a/letmeind/src/main.rs
+++ b/letmeind/src/main.rs
@@ -13,6 +13,7 @@ std::compile_error!("letmeind server does not support non-Linux platforms.");
 
 mod firewall_client;
 mod ip_limiter;
+mod logging;
 mod protocol;
 mod seccomp;
 mod server;
@@ -129,6 +130,17 @@ impl Opts {
     }
 }
 
+fn is_expected_connection_error(err: &str) -> bool {
+    matches!(
+        err,
+        s if s.starts_with("Unknown user:")
+            || s.starts_with("Unknown resource:")
+            || s.starts_with("Access denied:")
+            || s == "Knock: Authentication failed"
+            || s == "ComeIn: Authentication failed"
+    )
+}
+
 async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
     // Create directories in /run
     make_run_subdir(&opts.rundir)?;
@@ -180,9 +192,12 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
                         // Limit the number of simultaneous connections from the same IP address.
                         if !ip_limiter.request_permit_ok(peer_ip) {
                             conn.close().await;
-                            eprintln!(
-                                "Client '{peer_ip}': ERROR: \
-                                Too many simultaneous connections. Dropping connection."
+                            log_security!(
+                                WARN,
+                                "CONN_LIMIT_EXCEEDED",
+                                peer_ip,
+                                conn.l4proto()
+                                => "Per-IP simultaneous connection limit exceeded. Connection dropped."
                             );
                             continue;
                         }
@@ -201,12 +216,19 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
                             async move {
                                 let mut proto = Protocol::new(&*conn, &conf, &opts.rundir);
                                 if let Err(e) = proto.run().await {
-                                    eprintln!(
-                                        "Client '{}/{}' ERROR: {}",
-                                        conn.peer_addr(),
-                                        conn.l4proto(),
-                                        e
-                                    );
+                                    let e = e.to_string();
+                                    // Security events that have a dedicated log_security! call
+                                    // inside Protocol::run() do not need a second line here.
+                                    // This catch-all covers unexpected I/O errors and
+                                    // early disconnects that are not security events.
+                                    if !is_expected_connection_error(&e) {
+                                        eprintln!(
+                                            "letmeind: peer={}/{} -- Connection error: {}",
+                                            conn.peer_addr().ip(),
+                                            conn.l4proto(),
+                                            e
+                                        );
+                                    }
                                 }
                                 conn.close().await;
                                 drop(permit);

--- a/letmeind/src/protocol.rs
+++ b/letmeind/src/protocol.rs
@@ -6,11 +6,11 @@
 // or the MIT license, at your option.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{firewall_client::FirewallClient, server::ConnectionOps};
+use crate::{firewall_client::FirewallClient, log_security, server::ConnectionOps};
 use anyhow::{self as ah, format_err as err};
 use letmein_conf::{Config, ErrorPolicy, Resource};
 use letmein_proto::{Message, Operation, ResourceId, UserId};
-use std::path::Path;
+use std::{net::IpAddr, path::Path};
 use tokio::time::timeout;
 
 /// Protocol authentication state.
@@ -32,6 +32,10 @@ pub struct Protocol<'a, C> {
     conn: &'a C,
     conf: &'a Config,
     rundir: &'a Path,
+    /// IP address of the remote peer (for logging).
+    peer_ip: IpAddr,
+    /// Layer-4 protocol label (for logging).
+    proto: &'a str,
     user_id: Option<UserId>,
     resource_id: Option<ResourceId>,
     auth_state: AuthState,
@@ -39,10 +43,14 @@ pub struct Protocol<'a, C> {
 
 impl<'a, C: ConnectionOps> Protocol<'a, C> {
     pub fn new(conn: &'a C, conf: &'a Config, rundir: &'a Path) -> Self {
+        let peer_ip = conn.peer_addr().ip();
+        let proto = conn.l4proto();
         Self {
             conn,
             conf,
             rundir,
+            peer_ip,
+            proto,
             user_id: None,
             resource_id: None,
             auth_state: AuthState::NotAuth,
@@ -50,37 +58,113 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
     }
 
     async fn recv_msg(&mut self, expect_operation: &[Operation]) -> ah::Result<Message> {
-        if let Some(msg) = timeout(self.conf.control_timeout(), self.conn.recv_msg())
-            .await
-            .map_err(|_| err!("RX communication with peer timed out"))??
-        {
-            if !expect_operation.contains(&msg.operation()) {
-                return self
-                    .send_go_away(Err(err!(
-                        "Invalid reply message operation. Expected {:?}, got {:?}",
-                        expect_operation,
-                        msg.operation()
-                    )))
-                    .await;
+        let msg_result = timeout(self.conf.control_timeout(), self.conn.recv_msg()).await;
+
+        // Distinguish pre-auth timeout from post-auth timeout for fail2ban differentiation.
+        let msg_result_inner = match msg_result {
+            Err(_elapsed) => {
+                if self.auth_state == AuthState::NotAuth {
+                    log_security!(
+                        WARN,
+                        "PREAUTH_TIMEOUT",
+                        self.peer_ip,
+                        self.proto
+                        => "Connection timed out before client sent initial message"
+                    );
+                } else {
+                    log_security!(
+                        WARN,
+                        "POSTAUTH_TIMEOUT",
+                        self.peer_ip,
+                        self.proto
+                        => "Connection timed out mid-sequence after authentication"
+                    );
+                }
+                return Err(err!("RX communication with peer timed out"));
             }
-            if let Some(user_id) = self.user_id
-                && msg.user() != user_id
-            {
-                return self
-                    .send_go_away(Err(err!("Received message user mismatch")))
-                    .await;
-            }
-            if let Some(resource_id) = self.resource_id
-                && msg.resource() != resource_id
-            {
-                return self
-                    .send_go_away(Err(err!("Received message resource mismatch")))
-                    .await;
-            }
-            Ok(msg)
-        } else {
-            Err(err!("Disconnected."))
+            Ok(inner) => inner,
+        };
+
+        // Propagate any socket-level I/O or deserialization errors.
+        // A malformed datagram (wrong size, invalid magic, unknown operation value)
+        // is indistinguishable from active probing/fuzzing - log it before dropping.
+        let msg_opt = msg_result_inner.map_err(|e| {
+            log_security!(
+                WARN,
+                "PROTOCOL_ABUSE",
+                self.peer_ip,
+                self.proto,
+                &format!("detail={e}")
+                => "Malformed message received; connection dropped"
+            );
+            e
+        })?;
+
+        let Some(msg) = msg_opt else {
+            return Err(err!("Disconnected."));
+        };
+
+        // Validate that the operation is expected at this stage of the sequence.
+        if !expect_operation.contains(&msg.operation()) {
+            log_security!(
+                ERROR,
+                "PROTOCOL_ABUSE",
+                self.peer_ip,
+                self.proto,
+                &format!(
+                    "expected={:?} got={:?}",
+                    expect_operation,
+                    msg.operation()
+                )
+                => "Unexpected message operation - protocol sequence violated"
+            );
+            return self
+                .send_go_away(Err(err!(
+                    "Invalid reply message operation. Expected {:?}, got {:?}",
+                    expect_operation,
+                    msg.operation()
+                )))
+                .await;
         }
+
+        // Validate that the user ID has not changed mid-session.
+        if let Some(user_id) = self.user_id
+            && msg.user() != user_id
+        {
+            log_security!(
+                ERROR,
+                "PROTOCOL_ABUSE",
+                self.peer_ip,
+                self.proto,
+                &format!("expected_user={user_id} got_user={}", msg.user())
+                => "User ID changed mid-session"
+            );
+            return self
+                .send_go_away(Err(err!("Received message user mismatch")))
+                .await;
+        }
+
+        // Validate that the resource ID has not changed mid-session.
+        if let Some(resource_id) = self.resource_id
+            && msg.resource() != resource_id
+        {
+            log_security!(
+                ERROR,
+                "PROTOCOL_ABUSE",
+                self.peer_ip,
+                self.proto,
+                &format!(
+                    "expected_resource={resource_id} got_resource={}",
+                    msg.resource()
+                )
+                => "Resource ID changed mid-session"
+            );
+            return self
+                .send_go_away(Err(err!("Received message resource mismatch")))
+                .await;
+        }
+
+        Ok(msg)
     }
 
     async fn send_msg(&mut self, msg: &Message) -> ah::Result<()> {
@@ -110,8 +194,14 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
                 ))
                 .await
             {
-                // Only print a log message and ignore the error.
-                eprintln!("Failed to send GoAway reply: {e}");
+                // Log with peer context so it can be correlated in journal.
+                log_security!(
+                    WARN,
+                    "GOAWAY_SEND_FAILED",
+                    self.peer_ip,
+                    self.proto
+                    => &format!("Failed to send GoAway reply: {e}")
+                );
             }
         }
 
@@ -137,6 +227,7 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
         self.auth_state = AuthState::NotAuth;
 
         // Receive the initial knock/revoke message.
+        // recv_msg() will log PREAUTH_TIMEOUT or PROTOCOL_ABUSE itself on failure.
         let initial_message = self
             .recv_msg(&[Operation::Knock, Operation::Revoke])
             .await?;
@@ -149,16 +240,31 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
         let resource_id = initial_message.resource();
         self.resource_id = Some(resource_id);
 
-        // Get the shared key.
+        // Get the shared key - log unknown user ID.
         let Some(key) = self.conf.key(user_id) else {
+            log_security!(
+                WARN,
+                "UNKNOWN_USER",
+                self.peer_ip,
+                self.proto,
+                &format!("user={user_id}")
+                => "User ID not found in server configuration"
+            );
             return self
                 .send_go_away(Err(err!("Unknown user: {user_id}")))
                 .await;
         };
 
-        // Authenticate the received message.
-        // This check is not replay-safe. But that's fine.
+        // Authenticate the received message (not replay-safe, but that's by design).
         if !initial_message.check_auth_ok_no_challenge(key) {
+            log_security!(
+                WARN,
+                "AUTH_FAILURE",
+                self.peer_ip,
+                self.proto,
+                &format!("user={user_id} resource={resource_id} stage=knock")
+                => "Initial knock authentication (HMAC) failed"
+            );
             return self
                 .send_go_away(Err(err!("Knock: Authentication failed")))
                 .await;
@@ -167,6 +273,14 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
 
         // Get the requested resource from the configuration.
         let Some(resource) = self.conf.resource(resource_id) else {
+            log_security!(
+                WARN,
+                "UNKNOWN_RESOURCE",
+                self.peer_ip,
+                self.proto,
+                &format!("user={user_id} resource={resource_id}")
+                => "Resource ID not found in server configuration"
+            );
             return self
                 .send_go_away(Err(err!("Unknown resource: {resource_id}")))
                 .await;
@@ -174,6 +288,14 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
 
         // Check if the authenticating user is allowed to access this resource.
         if !resource.contains_user(user_id) {
+            log_security!(
+                WARN,
+                "ACCESS_DENIED",
+                self.peer_ip,
+                self.proto,
+                &format!("user={user_id} resource={resource_id}")
+                => "Authenticated user is not permitted to access this resource"
+            );
             return self
                 .send_go_away(Err(err!(
                     "Resource {resource_id} not allowed for user {user_id}"
@@ -213,10 +335,19 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
         self.send_msg(&challenge).await?;
 
         // Receive the response.
+        // recv_msg() will log PROTOCOL_ABUSE / timeout events itself on failure.
         let response = self.recv_msg(&[Operation::Response]).await?;
 
         // Authenticate the challenge-response.
         if !response.check_auth_ok(key, challenge) {
+            log_security!(
+                WARN,
+                "AUTH_FAILURE",
+                self.peer_ip,
+                self.proto,
+                &format!("user={user_id} resource={resource_id} stage=challenge-response")
+                => "Challenge-response authentication (HMAC) failed"
+            );
             return self
                 .send_go_away(Err(err!("Response: Authentication failed")))
                 .await;
@@ -235,7 +366,7 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
                     .await
             }
             Operation::Revoke => {
-                // Send an revoke-rules request to letmeinfwd.
+                // Send a revoke-rules request to letmeinfwd.
                 self.connect_to_fw()
                     .await?
                     .revoke_rules(user_id, resource_id, peer_ip_addr, conf_checksum)
@@ -251,14 +382,19 @@ impl<'a, C: ConnectionOps> Protocol<'a, C> {
                 .await;
         }
 
-        let logaction = if initial_operation == Operation::Knock {
-            "knocked"
+        // Log the successful outcome with structured event keyword.
+        let (event, action) = if initial_operation == Operation::Knock {
+            ("KNOCK_SUCCESS", "knocked")
         } else {
-            "revoked"
+            ("REVOKE_SUCCESS", "revoked")
         };
-        println!(
-            "[{peer_ip_addr}]: Resource {resource_id} successfully {logaction}. \
-             Firewall rules changed.",
+        log_security!(
+            INFO,
+            event,
+            self.peer_ip,
+            self.proto,
+            &format!("user={user_id} resource={resource_id}")
+            => &format!("Resource {resource_id} successfully {action}. Firewall rules changed.")
         );
 
         // Send a come-in message.

--- a/letmeind/src/seccomp.rs
+++ b/letmeind/src/seccomp.rs
@@ -33,6 +33,10 @@ const ALLOW_LIST: [Allow; 13] = [
 /// Install the `seccomp` rules, if requested.
 pub fn install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
     if seccomp == Seccomp::Off {
+        eprintln!(
+            "letmeind: [WARN] SECCOMP_DISABLED -- \
+            Seccomp syscall filter is disabled by configuration"
+        );
         return Ok(());
     }
 
@@ -44,15 +48,19 @@ pub fn install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
 
     // Install seccomp filter.
     if seccomp_supported() {
-        println!("Seccomp mode: {seccomp}");
         Filter::compile(&ALLOW_LIST, action)
             .context("Compile seccomp filter")?
             .install()
             .context("Install seccomp filter")?;
+        eprintln!(
+            "letmeind: [INFO] SECCOMP_ACTIVE mode={seccomp} -- \
+            Seccomp syscall filter installed successfully"
+        );
     } else {
         eprintln!(
-            "WARNING: Not using seccomp. \
-            Letmein does not support seccomp on this architecture, yet."
+            "letmeind: [WARN] SECCOMP_UNAVAILABLE -- \
+            Seccomp is not supported on this architecture; \
+            syscall filter not active"
         );
     }
 

--- a/letmeinfwd/src/firewall.rs
+++ b/letmeinfwd/src/firewall.rs
@@ -269,15 +269,15 @@ trait LeaseMapOps {
 
 impl<K> LeaseMapOps for HashMap<K, Lease> {
     fn prune_timeouts(&mut self, conf: &Config) -> Vec<Lease> {
+        let _ = conf; // conf may be used for future per-resource timeout config
         let mut pruned = vec![];
         let now = Instant::now();
         self.retain(|_, lease| {
             let timed_out = lease.is_timed_out(now);
             if timed_out {
                 pruned.push(lease.clone());
-                if conf.debug() {
-                    println!("firewall: {lease} timed out");
-                }
+                // Always log lease expiry - useful for SIEM audit trails.
+                eprintln!("letmeinfwd: [INFO] LEASE_EXPIRED -- {lease}");
             }
             !timed_out
         });

--- a/letmeinfwd/src/firewall/nftables.rs
+++ b/letmeinfwd/src/firewall/nftables.rs
@@ -117,6 +117,15 @@ fn statement_match_saddr<'a>(family: NfFamily, addr: IpAddr) -> ah::Result<State
         IpAddr::V4(addr) => match family {
             NfFamily::INet | NfFamily::IP => ("ip", addr.to_string()),
             _ => {
+                // Rule will not be installed - nftables family is IPv6-only but client
+                // address is IPv4.  The knock will fail safely (port stays closed) but
+                // the operator needs to know their nft-family setting is mismatched.
+                eprintln!(
+                    "letmeinfwd: [WARN] FIREWALL_RULE_SKIPPED \
+                    reason=ip_family_mismatch peer={addr} family={family:?} \
+                    -- IPv4 client address not compatible with configured nftables family; \
+                    rule not installed"
+                );
                 return Err(err!("IP version not supported by nftables firewall family"));
             }
         },
@@ -125,6 +134,12 @@ fn statement_match_saddr<'a>(family: NfFamily, addr: IpAddr) -> ah::Result<State
                 match family {
                     NfFamily::INet | NfFamily::IP => ("ip", addr.to_string()),
                     _ => {
+                        eprintln!(
+                            "letmeinfwd: [WARN] FIREWALL_RULE_SKIPPED \
+                            reason=ip_family_mismatch peer={addr} family={family:?} \
+                            -- IPv4-mapped IPv6 address not compatible with configured \
+                            nftables family; rule not installed"
+                        );
                         return Err(err!("IP version not supported by nftables firewall family"));
                     }
                 }
@@ -132,6 +147,12 @@ fn statement_match_saddr<'a>(family: NfFamily, addr: IpAddr) -> ah::Result<State
                 match family {
                     NfFamily::INet | NfFamily::IP6 => ("ip6", addr.to_string()),
                     _ => {
+                        eprintln!(
+                            "letmeinfwd: [WARN] FIREWALL_RULE_SKIPPED \
+                            reason=ip_family_mismatch peer={addr} family={family:?} \
+                            -- IPv6 client address not compatible with configured nftables family; \
+                            rule not installed"
+                        );
                         return Err(err!("IP version not supported by nftables firewall family"));
                     }
                 }
@@ -208,6 +229,14 @@ fn gen_rule_comment(
     write!(&mut comment, "LETMEIN")?;
 
     if comment.len() > NFTNL_UDATA_COMMENT_MAXLEN {
+        // Rule will not be installed - log so the operator can diagnose the
+        // misconfiguration (e.g. a jump target chain name that is too long).
+        eprintln!(
+            "letmeinfwd: [WARN] FIREWALL_RULE_SKIPPED \
+            reason=comment_too_long length={} max={NFTNL_UDATA_COMMENT_MAXLEN} \
+            -- nftables rule comment exceeds maximum length; rule not installed",
+            comment.len(),
+        );
         Err(err!(
             "Could not generate nftables rule comment. \
             The length {} is longer than the maximum of {}.",
@@ -659,8 +688,10 @@ impl NftFirewallInner {
     /// and rebuild the whole table on failure.
     async fn nftables_remove_leases(&mut self, conf: &Config, leases: &[Lease]) -> ah::Result<()> {
         if let Err(e) = self.nftables_remove_leases_no_rebuild(conf, leases).await {
-            eprintln!("WARNING: Failed to remove lease(s): {e:?}");
-            eprintln!("Trying full rebuild.");
+            eprintln!(
+                "letmeinfwd: [WARN] FIREWALL_REBUILD_TRIGGERED -- \
+                Failed to remove lease(s), attempting full table rebuild: {e:?}"
+            );
             self.nftables_full_rebuild(conf).await?;
         }
         Ok(())

--- a/letmeinfwd/src/main.rs
+++ b/letmeinfwd/src/main.rs
@@ -246,7 +246,7 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
                         if let Ok(permit) = conn_semaphore.acquire_owned().await {
                             task::spawn(async move {
                                 if let Err(e) = conn.handle_message(&conf, fw).await {
-                                    eprintln!("Client error: {e:?}");
+                                    eprintln!("letmeinfwd: [WARN] -- IPC handler error: {e:?}");
                                 }
                                 drop(permit);
                             });
@@ -304,7 +304,13 @@ async fn async_main(opts: Arc<Opts>) -> ah::Result<()> {
     // Try to remove all firewall rules.
     {
         if let Err(e) = fw.shutdown(&conf).await {
-            eprintln!("WARNING: Failed to remove firewall rules: {e:?}");
+            // Log as ERROR - firewall rules may remain active after daemon exit,
+            // leaving ports open beyond their intended lease lifetime.
+            eprintln!(
+                "letmeinfwd: [ERROR] FIREWALL_SHUTDOWN_FAILED -- \
+                Failed to remove firewall rules on shutdown. \
+                Leased ports may remain open in the firewall: {e:?}"
+            );
             if exitcode.is_ok() {
                 exitcode = Err(err!("Failed to remove firewall rules"));
             }

--- a/letmeinfwd/src/seccomp.rs
+++ b/letmeinfwd/src/seccomp.rs
@@ -47,6 +47,10 @@ const ALLOW_LIST: [Allow; 29] = [
 /// Install the `seccomp` rules, if requested.
 pub fn install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
     if seccomp == Seccomp::Off {
+        eprintln!(
+            "letmeinfwd: [WARN] SECCOMP_DISABLED -- \
+            Seccomp syscall filter is disabled by configuration"
+        );
         return Ok(());
     }
 
@@ -58,15 +62,19 @@ pub fn install_seccomp_rules(seccomp: Seccomp) -> ah::Result<()> {
 
     // Install seccomp filter.
     if seccomp_supported() {
-        println!("Seccomp mode: {seccomp}");
         Filter::compile(&ALLOW_LIST, action)
             .context("Compile seccomp filter")?
             .install()
             .context("Install seccomp filter")?;
+        eprintln!(
+            "letmeinfwd: [INFO] SECCOMP_ACTIVE mode={seccomp} -- \
+            Seccomp syscall filter installed successfully"
+        );
     } else {
         eprintln!(
-            "WARNING: Not using seccomp. \
-            Letmein does not support seccomp on this architecture, yet."
+            "letmeinfwd: [WARN] SECCOMP_UNAVAILABLE -- \
+            Seccomp is not supported on this architecture; \
+            syscall filter not active"
         );
     }
 

--- a/letmeinfwd/src/server.rs
+++ b/letmeinfwd/src/server.rs
@@ -123,7 +123,15 @@ impl FirewallConnection {
     async fn recv_msg(&mut self) -> ah::Result<Option<FirewallMessage>> {
         timeout(RECV_TIMEOUT, FirewallMessage::recv(&mut self.stream))
             .await
-            .map_err(|_| err!("IPC receive timed out."))?
+            .map_err(|_| {
+                // An authenticated letmeind connection timed out before sending a
+                // complete IPC message.  This should never happen in normal operation.
+                eprintln!(
+                    "letmeinfwd: [WARN] IPC_TIMEOUT -- \
+                    Timed out waiting for IPC message from letmeind; connection dropped"
+                );
+                err!("IPC receive timed out.")
+            })?
     }
 
     async fn send_msg(&mut self, msg: &FirewallMessage) -> ah::Result<()> {
@@ -145,10 +153,24 @@ impl FirewallConnection {
         msg: &FirewallMessage,
     ) -> ah::Result<()> {
         let Some(conf_cs) = msg.conf_checksum() else {
+            // Missing checksum - legitimate letmeind always includes this.
+            eprintln!(
+                "letmeinfwd: [WARN] IPC_MALFORMED_MESSAGE \
+                reason=missing_checksum \
+                -- IPC message contained no configuration checksum; request rejected"
+            );
             let res = Err(err!("No configuration checksum in message."));
             return self.send_result(res).await;
         };
         if *conf_cs != *conf.checksum() {
+            // Log before returning - this means letmeind and letmeinfwd loaded
+            // different versions of letmeind.conf.  Possible mid-flight config
+            // change or failed deployment.  Firewall request will be rejected.
+            eprintln!(
+                "letmeinfwd: [WARN] IPC_CONF_MISMATCH -- \
+                letmeind.conf checksum mismatch between letmeind and letmeinfwd. \
+                Firewall request rejected. Check that both daemons use the same config file."
+            );
             let res = Err(err!(
                 "letmeind.conf checksum mismatch between letmeind and letmeinfwd."
             ));
@@ -159,11 +181,23 @@ impl FirewallConnection {
 
     async fn get_addr(&mut self, msg: &FirewallMessage) -> ah::Result<IpAddr> {
         let Some(addr) = msg.addr() else {
+            // Missing address in a well-formed IPC message - should never happen
+            // with a legitimate letmeind.  Log as a malformed IPC message.
+            eprintln!(
+                "letmeinfwd: [WARN] IPC_MALFORMED_MESSAGE \
+                reason=missing_address \
+                -- IPC message contained no client address; request rejected"
+            );
             let res = Err(err!("No address in message."));
             return self.send_result(res).await;
         };
         // Check if addr is valid.
         if !addr_check(&addr) {
+            eprintln!(
+                "letmeinfwd: [WARN] IPC_MALFORMED_MESSAGE \
+                reason=invalid_address addr={addr} \
+                -- IPC message contained an invalid client address; request rejected"
+            );
             let res = Err(err!("Invalid address in message."));
             return self.send_result(res).await;
         }
@@ -255,6 +289,14 @@ impl FirewallConnection {
                 }
             },
             FirewallOperation::Ack | FirewallOperation::Nack => {
+                // Ack/Nack are reply operations - letmeind should never send these
+                // as requests.  This is a protocol violation.
+                eprintln!(
+                    "letmeinfwd: [WARN] IPC_MALFORMED_MESSAGE \
+                    reason=invalid_operation op={:?} \
+                    -- IPC message used a reply operation as a request; rejected",
+                    msg.operation()
+                );
                 Err(err!("Received invalid message"))
             }
         }
@@ -337,10 +379,19 @@ impl FirewallServer {
         // This is an additional check that is not strictly needed for the security
         // concept. The socket is only accessible by the `letmeind` group and user.
         let Some(pid) = cred.pid() else {
+            eprintln!(
+                "letmeinfwd: [ERROR] IPC_UNAUTHORIZED_CONNECT -- \
+                Unix socket connection rejected: peer PID could not be determined"
+            );
             return Err(err!("The connected pid is not known. Rejecting."));
         };
         let expected_pid = get_letmeind_pid(&self.rundir).await?;
         if pid != expected_pid {
+            eprintln!(
+                "letmeinfwd: [ERROR] IPC_UNAUTHORIZED_CONNECT \
+                connected_pid={pid} expected_pid={expected_pid} \
+                -- Unix socket connection rejected: PID does not match letmeind"
+            );
             return Err(err!(
                 "The connected pid {pid} is not letmeind ({expected_pid}). Rejecting."
             ));
@@ -351,6 +402,13 @@ impl FirewallServer {
             // This is an additional check that is not strictly needed for the security
             // concept. The socket is only accessible by the `letmeind` group and user.
             if cred.uid() != LETMEIND_UID.load(Relaxed) {
+                eprintln!(
+                    "letmeinfwd: [ERROR] IPC_UNAUTHORIZED_CONNECT \
+                    connected_uid={} expected_uid={} \
+                    -- Unix socket connection rejected: UID does not match letmeind user",
+                    cred.uid(),
+                    LETMEIND_UID.load(Relaxed),
+                );
                 return Err(err!(
                     "The connected uid {} is not letmeind ({}). Rejecting. \
                     Please ensure that the 'letmeind' daemon is running as 'letmeind' user.",
@@ -359,6 +417,13 @@ impl FirewallServer {
                 ));
             }
             if cred.gid() != LETMEIND_GID.load(Relaxed) {
+                eprintln!(
+                    "letmeinfwd: [ERROR] IPC_UNAUTHORIZED_CONNECT \
+                    connected_gid={} expected_gid={} \
+                    -- Unix socket connection rejected: GID does not match letmeind group",
+                    cred.gid(),
+                    LETMEIND_GID.load(Relaxed),
+                );
                 return Err(err!(
                     "The connected gid {} is not letmeind ({}). Rejecting. \
                     Please ensure that the 'letmeind' daemon is running as 'letmeind' group.",

--- a/scripts/fail2ban/filter.d/letmeind-abuse.conf
+++ b/scripts/fail2ban/filter.d/letmeind-abuse.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/filter.d/letmeind-abuse.conf

--- a/scripts/fail2ban/filter.d/letmeind-auth.conf
+++ b/scripts/fail2ban/filter.d/letmeind-auth.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/filter.d/letmeind-auth.conf

--- a/scripts/fail2ban/filter.d/letmeind-probe.conf
+++ b/scripts/fail2ban/filter.d/letmeind-probe.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/filter.d/letmeind-probe.conf

--- a/scripts/fail2ban/filter.d/letmeind-scan.conf
+++ b/scripts/fail2ban/filter.d/letmeind-scan.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/filter.d/letmeind-scan.conf

--- a/scripts/fail2ban/filter.d/letmeind.conf
+++ b/scripts/fail2ban/filter.d/letmeind.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/filter.d/letmeind.conf

--- a/scripts/fail2ban/jail.d/letmeind.conf
+++ b/scripts/fail2ban/jail.d/letmeind.conf
@@ -1,0 +1,1 @@
+../../../letmein-fail2ban/configs/jail.d/letmeind.conf


### PR DESCRIPTION
It introduces standard event keywords and machine-readable (fail2ban) fields for authentication failures, unknown users/resources, access denials, protocol abuse, timeouts, and successful knocks, documented in doc/SECURITY_LOGGING.md. It also adds ready-to-use fail2ban filters/jails and removes redundant generic error logging for expected security rejections so logs are cleaner and more actionable.

Did have some help with this one from IBM Bob (esp the doc and tests)